### PR TITLE
Big map view annotations

### DIFF
--- a/PittsburghCityBridges.xcodeproj/project.pbxproj
+++ b/PittsburghCityBridges.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		2410128B2713787200FE7DEC /* BridgePhotosView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2410128A2713787200FE7DEC /* BridgePhotosView.swift */; };
 		2410128D2713855400FE7DEC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2410128C2713855400FE7DEC /* ContentView.swift */; };
 		2419B8B9271F382600BFE3D8 /* BridgeMapUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2419B8B8271F382600BFE3D8 /* BridgeMapUIView.swift */; };
-		2419B8BB271F3CD900BFE3D8 /* CityAppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2419B8BA271F3CD900BFE3D8 /* CityAppModel.swift */; };
+		2419B8BB271F3CD900BFE3D8 /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2419B8BA271F3CD900BFE3D8 /* MapViewModel.swift */; };
 		2419B8BD2721843800BFE3D8 /* BridgeMapDetailAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2419B8BC2721843700BFE3D8 /* BridgeMapDetailAccessoryView.swift */; };
 		2419B8C42721D64E00BFE3D8 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2419B8C32721D64E00BFE3D8 /* LocationManager.swift */; };
 		244A747427187D1200284608 /* BridgeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244A747327187D1200284608 /* BridgeModel.swift */; };
@@ -52,7 +52,7 @@
 		2410128A2713787200FE7DEC /* BridgePhotosView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgePhotosView.swift; sourceTree = "<group>"; };
 		2410128C2713855400FE7DEC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		2419B8B8271F382600BFE3D8 /* BridgeMapUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeMapUIView.swift; sourceTree = "<group>"; };
-		2419B8BA271F3CD900BFE3D8 /* CityAppModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityAppModel.swift; sourceTree = "<group>"; };
+		2419B8BA271F3CD900BFE3D8 /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 		2419B8BC2721843700BFE3D8 /* BridgeMapDetailAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeMapDetailAccessoryView.swift; sourceTree = "<group>"; };
 		2419B8C32721D64E00BFE3D8 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		244A747327187D1200284608 /* BridgeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeModel.swift; sourceTree = "<group>"; };
@@ -118,7 +118,7 @@
 			children = (
 				244A747327187D1200284608 /* BridgeModel.swift */,
 				244E9C90273ABF2A00605134 /* BridgeListViewModel.swift */,
-				2419B8BA271F3CD900BFE3D8 /* CityAppModel.swift */,
+				2419B8BA271F3CD900BFE3D8 /* MapViewModel.swift */,
 				244A74792719A1A600284608 /* GEOJSONModels.swift */,
 			);
 			path = Models;
@@ -303,7 +303,7 @@
 				2410128D2713855400FE7DEC /* ContentView.swift in Sources */,
 				248FC58C270276EE00BE168F /* Persistence.swift in Sources */,
 				24B3FE9427236968004B93A6 /* ImageViewLoader.swift in Sources */,
-				2419B8BB271F3CD900BFE3D8 /* CityAppModel.swift in Sources */,
+				2419B8BB271F3CD900BFE3D8 /* MapViewModel.swift in Sources */,
 				24B3FEB327277379004B93A6 /* BridgeImageView.swift in Sources */,
 				241012662713757900FE7DEC /* PittsburghCityBridges.xcdatamodeld in Sources */,
 				2419B8BD2721843800BFE3D8 /* BridgeMapDetailAccessoryView.swift in Sources */,

--- a/PittsburghCityBridges/Models/CityAppModel.swift
+++ b/PittsburghCityBridges/Models/CityAppModel.swift
@@ -8,12 +8,27 @@
 import Foundation
 import MapKit
 
-struct CityModel {
+struct MapViewModel {
     static let centerLatitude: Double = 40.44101670487502
     static let centerLongitude: Double = -79.99554306389608
     static let centerLocationCoordiante2D =  CLLocationCoordinate2D(latitude: centerLatitude, longitude: centerLongitude)
-    static let cityRegionRadius: CLLocationDistance = 10_000
-    static let cityRegion = MKCoordinateRegion(center: centerLocationCoordiante2D, latitudinalMeters: cityRegionRadius, longitudinalMeters: cityRegionRadius)
     static let singleBridgeRegionRadius: CLLocationDistance = 100
     static let singleBridgeRegion = MKCoordinateRegion(center: centerLocationCoordiante2D, latitudinalMeters: singleBridgeRegionRadius, longitudinalMeters: singleBridgeRegionRadius)
+    
+    var multipleBridgesRegionRadius: CLLocationDistance {
+        let regionRadius: CLLocationDistance
+        if UIDevice.current.userInterfaceIdiom == .phone {
+                regionRadius = 5_000
+            } else {
+                regionRadius = 12_500
+            }
+        return regionRadius
+    }
+    
+    var multipleBridgesRegion: MKCoordinateRegion {
+        return MKCoordinateRegion(center: MapViewModel.centerLocationCoordiante2D,
+                                  latitudinalMeters: multipleBridgesRegionRadius,
+                                  longitudinalMeters: multipleBridgesRegionRadius)
+        
+    }
 }

--- a/PittsburghCityBridges/Models/MapViewModel.swift
+++ b/PittsburghCityBridges/Models/MapViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  CityAppModel.swift
+//  MapViewModel.swift
 //  PittsburghCityBridges
 //
 //  Created by MAKinney on 10/19/21.

--- a/PittsburghCityBridges/Views/BridgeDetailsView.swift
+++ b/PittsburghCityBridges/Views/BridgeDetailsView.swift
@@ -117,7 +117,7 @@ struct BridgeDetailsView: View {
     
     func makeMapView(_ bridgeModel: BridgeModel) -> some View {
         ZStack {
-            BridgeMapUIView(region: CityModel.singleBridgeRegion, bridgeModels: [bridgeModel], hasDetailAccessoryView: false)
+            BridgeMapUIView(region: MapViewModel.singleBridgeRegion, bridgeModels: [bridgeModel], hasDetailAccessoryView: false)
             Spacer()
             VStack {
                 HStack {

--- a/PittsburghCityBridges/Views/BridgeDetailsView.swift
+++ b/PittsburghCityBridges/Views/BridgeDetailsView.swift
@@ -124,7 +124,7 @@ struct BridgeDetailsView: View {
     
     func makeMapView(_ bridgeModel: BridgeModel) -> some View {
         ZStack {
-            BridgeMapUIView(region: MapViewModel.singleBridgeRegion, bridgeModels: [bridgeModel], hasDetailAccessoryView: false)
+            BridgeMapUIView(region: MapViewModel.singleBridgeRegion, bridgeModels: [bridgeModel], showsBridgeImage: false)
             Spacer()
             VStack {
                 HStack {

--- a/PittsburghCityBridges/Views/BridgeDetailsView.swift
+++ b/PittsburghCityBridges/Views/BridgeDetailsView.swift
@@ -32,6 +32,7 @@ struct BridgeDetailsView: View {
         let dragGesture =  DragGesture()
             .onChanged {
                 self.dragOffset = $0.translation
+                self.fadeOtherViews = true // so background view fades without having to first tap image
             }
         
         let magGesture = MagnificationGesture()
@@ -112,6 +113,12 @@ struct BridgeDetailsView: View {
                     .opacity(stickyDragAndMagMode ? 1 : 0)
                 }
             }
+        }
+        .onAppear() {
+            UIScrollView.appearance().bounces = false
+        }
+        .onDisappear {
+            UIScrollView.appearance().bounces = true
         }
     }
     

--- a/PittsburghCityBridges/Views/BridgeListView.swift
+++ b/PittsburghCityBridges/Views/BridgeListView.swift
@@ -36,7 +36,7 @@ struct BridgeListView: View {
                     .font(.headline)
                 }
             }
-            .navigationTitle("Bridges")
+            .navigationTitle("List of Bridges")
         
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {

--- a/PittsburghCityBridges/Views/BridgeMapDetailAccessoryView.swift
+++ b/PittsburghCityBridges/Views/BridgeMapDetailAccessoryView.swift
@@ -9,13 +9,9 @@ import SwiftUI
 struct BridgeMapDetailAccessoryView: View {
     var bridgeModel: BridgeModel
     var body: some View {
-        VStack(alignment: .leading) {
-            Text(bridgeModel.neighborhoods())
-            let built = bridgeModel.builtHistory()
-            if !built.isEmpty {
-                Text(built)
-            }
-        }
+        Image("HultonBridge")
+            .resizable()
+            .scaledToFit()
     }
 }
 

--- a/PittsburghCityBridges/Views/BridgeMapUIView.swift
+++ b/PittsburghCityBridges/Views/BridgeMapUIView.swift
@@ -90,16 +90,22 @@ struct BridgeMapUIView: UIViewRepresentable {
             } else {
                 annotationView = MKMarkerAnnotationView(annotation: bridgeMapAnnotation, reuseIdentifier: reuseIdentifier)
             }
-            annotationView.markerTintColor = .systemGreen
+            annotationView.glyphText = "Bridge"
+            annotationView.markerTintColor = .systemBlue
             annotationView.canShowCallout = true
             let buttonImage = UIImage(systemName: "arrow.triangle.turn.up.right.circle.fill") ?? UIImage()
             let directionsRequestButton = UIButton.systemButton(with: buttonImage, target: nil, action: nil) // so we can tap and get the delegate callback
             annotationView.rightCalloutAccessoryView = directionsRequestButton
             if hasDetailAccessoryView {
+//                let bridgeImage = UIImage(named: "HultonBridge") ?? UIImage()
+//                var imageView = UIImageView(image: bridgeImage)
+//                imageView.contentMode = ContentMode.fill
+//                annotationView.detailCalloutAccessoryView = imageView
                 let bridgeMapDetailAccessoryView = BridgeMapDetailAccessoryView(bridgeModel: bridgeMapAnnotation.bridgeModel)
                 let hostingController = UIHostingController(rootView: bridgeMapDetailAccessoryView)
                 hostingController.view.translatesAutoresizingMaskIntoConstraints = false
                 annotationView.detailCalloutAccessoryView = hostingController.view
+                annotationView.detailCalloutAccessoryView?.frame = CGRect(x: 0, y: 0, width: 50, height: 50)
             }
             return annotationView
         }

--- a/PittsburghCityBridges/Views/BridgeMapUIView.swift
+++ b/PittsburghCityBridges/Views/BridgeMapUIView.swift
@@ -17,11 +17,11 @@ struct BridgeMapUIView: UIViewRepresentable {
     let region: MKCoordinateRegion
     let hasDetailAccessoryView: Bool
     
-    init(region: MKCoordinateRegion, bridgeModels: [BridgeModel], hasDetailAccessoryView: Bool = true) {
+    init(region: MKCoordinateRegion, bridgeModels: [BridgeModel], showsBridgeImage: Bool = true) {
         logger.info("\(#file) \(#function)")
         self.region = region
         self.bridgeModels = bridgeModels
-        self.hasDetailAccessoryView = hasDetailAccessoryView
+        self.hasDetailAccessoryView = showsBridgeImage
     }
     
     func makeUIView(context: Context) -> MKMapView {

--- a/PittsburghCityBridges/Views/BridgeMapView.swift
+++ b/PittsburghCityBridges/Views/BridgeMapView.swift
@@ -11,7 +11,7 @@ struct BridgeMapView: View {
     @EnvironmentObject var bridgeStore: BridgeStore
     var body: some View {
         VStack {
-            BridgeMapUIView(region: MapViewModel().multipleBridgesRegion, bridgeModels: bridgeStore.bridgeModels)
+            BridgeMapUIView(region: MapViewModel().multipleBridgesRegion, bridgeModels: bridgeStore.bridgeModels, hasDetailAccessoryView: true)
         }
     }
 }

--- a/PittsburghCityBridges/Views/BridgeMapView.swift
+++ b/PittsburghCityBridges/Views/BridgeMapView.swift
@@ -11,7 +11,7 @@ struct BridgeMapView: View {
     @EnvironmentObject var bridgeStore: BridgeStore
     var body: some View {
         VStack {
-            BridgeMapUIView(region: CityModel.cityRegion, bridgeModels: bridgeStore.bridgeModels)
+            BridgeMapUIView(region: MapViewModel().multipleBridgesRegion, bridgeModels: bridgeStore.bridgeModels)
         }
     }
 }

--- a/PittsburghCityBridges/Views/BridgeMapView.swift
+++ b/PittsburghCityBridges/Views/BridgeMapView.swift
@@ -11,7 +11,7 @@ struct BridgeMapView: View {
     @EnvironmentObject var bridgeStore: BridgeStore
     var body: some View {
         VStack {
-            BridgeMapUIView(region: MapViewModel().multipleBridgesRegion, bridgeModels: bridgeStore.bridgeModels, hasDetailAccessoryView: true)
+            BridgeMapUIView(region: MapViewModel().multipleBridgesRegion, bridgeModels: bridgeStore.bridgeModels, showsBridgeImage: false)
         }
     }
 }

--- a/PittsburghCityBridges/Views/BridgePhotosView.swift
+++ b/PittsburghCityBridges/Views/BridgePhotosView.swift
@@ -29,7 +29,7 @@ struct BridgePhotosView: View {
                             }
                         }
                     }
-                    .navigationTitle("City Bridges")
+                    .navigationTitle("Photos of Bridges")
                 }
             }
         }

--- a/PittsburghCityBridges/Views/ContentView.swift
+++ b/PittsburghCityBridges/Views/ContentView.swift
@@ -12,13 +12,13 @@ struct ContentView: View {
 
     var body: some View {
         TabView {
-            BridgeListView(BridgeListViewModel(bridgeStore))
-                .tabItem {
-                    Label("Bridges", systemImage: "list.dash")
-                }
             BridgeMapView()
                 .tabItem {
                     Label("Map", systemImage: "map")
+                }
+            BridgeListView(BridgeListViewModel(bridgeStore))
+                .tabItem {
+                    Label("Bridges", systemImage: "list.dash")
                 }
             BridgePhotosView()
                 .tabItem {


### PR DESCRIPTION
Big Map Region based on device type of iPhone or iPad, show more content on iPAD
Detail accessory views no longer show neighbor and year built, as too much info for this view
Detail accessory views now show just bridge name, a directions arrow, and bridge image
Individual bridge images not yet implemented.  In this PR, image display is disabled, as only image is canned
But all is ready now for future refactored high speed image manager.
