### PR TITLE
Bridge views refactor

### DIFF
--- a/PittsburghCityBridges.xcodeproj/project.pbxproj
+++ b/PittsburghCityBridges.xcodeproj/project.pbxproj
@@ -145,13 +145,13 @@
 				2405C99C2767E1CF00C68307 /* BridgeImageLoadingProgressView.swift */,
 				240075D02716607B00CB864F /* BridgeListRow.swift */,
 				241012862713784D00FE7DEC /* BridgeListView.swift */,
+				24C65480276A855A006363B8 /* BridgeViewsView.swift */,
 				241012882713785C00FE7DEC /* BridgeMapView.swift */,
 				2419B8B8271F382600BFE3D8 /* BridgeMapUIView.swift */,
 				2419B8BC2721843700BFE3D8 /* BridgeMapDetailAccessoryView.swift */,
 				2410128A2713787200FE7DEC /* BridgePhotosView.swift */,
 				248FC584270276EA00BE168F /* CloudKitContentView.swift */,
 				2410128C2713855400FE7DEC /* ContentView.swift */,
-				24C65480276A855A006363B8 /* BridgeViewsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";

--- a/PittsburghCityBridges.xcodeproj/project.pbxproj
+++ b/PittsburghCityBridges.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		248FC59A270278F100BE168F /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 248FC599270278F100BE168F /* CloudKit.framework */; };
 		24B3FE8F272225B8004B93A6 /* MapExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B3FE8E272225B8004B93A6 /* MapExtensions.swift */; };
 		24B3FE912722356A004B93A6 /* DirectionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B3FE902722356A004B93A6 /* DirectionsProvider.swift */; };
+		24C65481276A855B006363B8 /* BridgeViewsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C65480276A855A006363B8 /* BridgeViewsView.swift */; };
 		24CC1B4E270A8ABE009BE390 /* BridgeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CC1B4D270A8ABE009BE390 /* BridgeStore.swift */; };
 /* End PBXBuildFile section */
 
@@ -77,6 +78,7 @@
 		248FC599270278F100BE168F /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
 		24B3FE8E272225B8004B93A6 /* MapExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapExtensions.swift; sourceTree = "<group>"; };
 		24B3FE902722356A004B93A6 /* DirectionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionsProvider.swift; sourceTree = "<group>"; };
+		24C65480276A855A006363B8 /* BridgeViewsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeViewsView.swift; sourceTree = "<group>"; };
 		24CC1B4D270A8ABE009BE390 /* BridgeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -149,6 +151,7 @@
 				2410128A2713787200FE7DEC /* BridgePhotosView.swift */,
 				248FC584270276EA00BE168F /* CloudKitContentView.swift */,
 				2410128C2713855400FE7DEC /* ContentView.swift */,
+				24C65480276A855A006363B8 /* BridgeViewsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -310,6 +313,7 @@
 				241012662713757900FE7DEC /* PittsburghCityBridges.xcdatamodeld in Sources */,
 				2419B8BD2721843800BFE3D8 /* BridgeMapDetailAccessoryView.swift in Sources */,
 				2410128B2713787200FE7DEC /* BridgePhotosView.swift in Sources */,
+				24C65481276A855B006363B8 /* BridgeViewsView.swift in Sources */,
 				24B3FE8F272225B8004B93A6 /* MapExtensions.swift in Sources */,
 				240075CF27150F5800CB864F /* BridgeDetailsView.swift in Sources */,
 				248FC585270276EA00BE168F /* CloudKitContentView.swift in Sources */,

--- a/PittsburghCityBridges/Services/BridgeImageSystem.swift
+++ b/PittsburghCityBridges/Services/BridgeImageSystem.swift
@@ -54,6 +54,7 @@ class BridgeImageSystem: ObservableObject {
     
     @MainActor
     func getThumbnailImage(url: URL?, size: CGSize = CGSize(width: 100, height: 100)) async -> UIImage? {
+        // SMALL, MIDDLE, LARGE THUMBNAILS FOR ENTIRE APP AND CACHE FOR EACH
         if let cachedThumbnailImage = cachedThumbnailImage {
             return cachedThumbnailImage
         }

--- a/PittsburghCityBridges/Views/BridgeListRow.swift
+++ b/PittsburghCityBridges/Views/BridgeListRow.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct BridgeListRow: View {
     var bridgeModel: BridgeModel
+
     var body: some View {
         HStack {
             VStack(alignment: .leading) {
@@ -20,8 +21,14 @@ struct BridgeListRow: View {
                 }
                 Spacer()
             }
+            .multilineTextAlignment(.leading)
+            .foregroundColor(.primary)
+            Spacer()
+            VStack {
+            Image(systemName: "arrow.forward")
+                Spacer()
+            }
         }
- //       .foregroundColor(Color("PiratesGold"))
     }
 }
 

--- a/PittsburghCityBridges/Views/BridgeListView.swift
+++ b/PittsburghCityBridges/Views/BridgeListView.swift
@@ -10,12 +10,13 @@ import SwiftUI
 struct BridgeListView: View {
     @EnvironmentObject var bridgeStore: BridgeStore
     @State private var showSheet = false
-    @State private var sectionListBy: BridgeListViewModel.SectionListBy = .neighborhood
+    private var sectionListBy: BridgeListViewModel.SectionListBy = .neighborhood
     
     private var bridgeListViewModel: BridgeListViewModel
     
-    init(_ bridgeListViewModel: BridgeListViewModel) {
+    init(_ bridgeListViewModel: BridgeListViewModel, sectionListBy: BridgeListViewModel.SectionListBy = .name) {
         self.bridgeListViewModel = bridgeListViewModel
+        self.sectionListBy = sectionListBy
         //      UITableView.appearance().backgroundColor = .green
     }
     
@@ -39,44 +40,10 @@ struct BridgeListView: View {
                 }
             }
             .navigationTitle(makeNavigationTitle(for: sectionListBy))
-            
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Menu(content: {
-                        Button {
-                            self.sectionListBy = .neighborhood
-                        } label: {
-                            makeCheckedLabel("Sort by Location", selectedSection: .neighborhood)
-                        }
-                        Button {
-                            self.sectionListBy = .name
-                        } label: {
-                            makeCheckedLabel("Sort by Name", selectedSection: .name)
-                        }
-                        Button {
-                            self.sectionListBy = .year
-                        } label: {
-                            makeCheckedLabel("Sort by Year", selectedSection: .year)
-                        }
-                    },
-                         label: {
-                        Label("Sort", systemImage: "arrow.down")
-                            .labelStyle(.titleAndIcon)
-                    })
-                }
-            }
         }
         //     .foregroundColor(Color.blue)
         .navigationViewStyle(StackNavigationViewStyle())
         
-    }
-    
-    private func makeCheckedLabel(_ name: String, selectedSection: BridgeListViewModel.SectionListBy) -> Label<Text, Image> {
-        if self.sectionListBy == selectedSection {
-            return Label(name, systemImage: "checkmark")
-        } else {
-            return Label(name, systemImage: "")
-        }
     }
     
     private func makeNavigationTitle(for selectedSection: BridgeListViewModel.SectionListBy) -> String {

--- a/PittsburghCityBridges/Views/BridgeListView.swift
+++ b/PittsburghCityBridges/Views/BridgeListView.swift
@@ -83,11 +83,11 @@ struct BridgeListView: View {
         var title = ""
         switch selectedSection {
         case .name:
-            title = "Bridges by Name"
+            title = "by Name"
         case .neighborhood:
-            title = "Bridges by Location"
+            title = "by Location"
         case .year:
-            title = "Bridges by Year"
+            title = "by Year Built"
         }
         return title
     }

--- a/PittsburghCityBridges/Views/BridgeListView.swift
+++ b/PittsburghCityBridges/Views/BridgeListView.swift
@@ -39,7 +39,7 @@ struct BridgeListView: View {
                     .font(.headline)
                 }
             }
-            .navigationTitle(makeNavigationTitle(for: sectionListBy))
+            .navigationBarHidden(true)
         }
         //     .foregroundColor(Color.blue)
         .navigationViewStyle(StackNavigationViewStyle())

--- a/PittsburghCityBridges/Views/BridgeListView.swift
+++ b/PittsburghCityBridges/Views/BridgeListView.swift
@@ -11,7 +11,6 @@ struct BridgeListView: View {
     @EnvironmentObject var bridgeStore: BridgeStore
     @State private var showSheet = false
     private var sectionListBy: BridgeListViewModel.SectionListBy = .neighborhood
-    
     private var bridgeListViewModel: BridgeListViewModel
     
     init(_ bridgeListViewModel: BridgeListViewModel, sectionListBy: BridgeListViewModel.SectionListBy = .name) {
@@ -22,41 +21,43 @@ struct BridgeListView: View {
     
     var body: some View {
         NavigationView {
-            List {
-                ForEach(bridgeListViewModel.sectionList(sectionListBy)) { bridgesSection in
-                    Section("\(bridgesSection.sectionName)") {
-                        ForEach(bridgesSection.bridgeModels) { bridgeModel in
-                            NavigationLink(destination: BridgeDetailsView(bridgeModel: bridgeModel)) {
-                                BridgeListRow(bridgeModel: bridgeModel)
+            ScrollView {
+                LazyVStack(spacing: 5, pinnedViews: [.sectionHeaders]) {
+                    ForEach(bridgeListViewModel.sectionList(sectionListBy)) { bridgesSection in
+                        Section {
+                            ForEach(bridgesSection.bridgeModels) { bridgeModel in
+                                NavigationLink(destination: BridgeDetailsView(bridgeModel: bridgeModel)) {
+                                    BridgeListRow(bridgeModel: bridgeModel)
+                                        .padding([.trailing, .leading], 10)
+                                }
                             }
+                            //               .background(Color("SteelersBlack"))
+                            .font(.body)
+                        } header: {
+                            HStack {
+                                Spacer()
+                                Text("\(bridgesSection.sectionName)")
+                                    .foregroundColor(Color("SteelersGold"))
+                                Spacer()
+                            }
+                                .background(Color("SteelersBlack"))
+     //                       .background(Color.white)
+//                            .background(Color.black)
                         }
-                        //               .background(Color("SteelersBlack"))
-                        .font(.body)
+                        
+                        //            .listRowBackground(Color.orange)
+                        //           .background(Color.orange)
+                        .font(.headline)
                     }
                     
-                    //            .listRowBackground(Color.orange)
-                    //           .background(Color.purple)
-                    .font(.headline)
                 }
+                //       .listStyle(.grouped)
             }
+            
             .navigationBarHidden(true)
         }
         //     .foregroundColor(Color.blue)
         .navigationViewStyle(StackNavigationViewStyle())
-        
-    }
-    
-    private func makeNavigationTitle(for selectedSection: BridgeListViewModel.SectionListBy) -> String {
-        var title = ""
-        switch selectedSection {
-        case .name:
-            title = "by Name"
-        case .neighborhood:
-            title = "by Location"
-        case .year:
-            title = "by Year Built"
-        }
-        return title
     }
 }
 

--- a/PittsburghCityBridges/Views/BridgePhotosView.swift
+++ b/PittsburghCityBridges/Views/BridgePhotosView.swift
@@ -25,10 +25,10 @@ struct BridgePhotosView: View {
         NavigationView {
             HStack {
                 Spacer()
-                List {
-                    ForEach(bridgeListViewModel.sectionList(sectionListBy)) { bridgesSection in
-                        Section("\(bridgesSection.sectionName)") {
-                       //     LazyVGrid(columns: columns) {
+                ScrollView {
+                    LazyVStack(spacing: 10, pinnedViews: [.sectionHeaders]) {
+                        ForEach(bridgeListViewModel.sectionList(sectionListBy)) { bridgesSection in
+                            Section {
                                 ForEach(bridgesSection.bridgeModels) { bridgeModel in
                                     if let imageURL = bridgeModel.imageURL {
                                         NavigationLink(destination: BridgeDetailsView(bridgeModel: bridgeModel)) {
@@ -36,41 +36,27 @@ struct BridgePhotosView: View {
                                         }
                                     }
                                 }
-                       //     }
-                            //               .background(Color("SteelersBlack"))
-                            .font(.body)
+                                //               .background(Color("SteelersBlack"))
+                                .font(.body)
+                            } header: {
+                                HStack {
+                                    Spacer()
+                                    Text("\(bridgesSection.sectionName)")
+                                    Spacer()
+                                }
+                                .background(Color.black)
+                            }
                         }
-                        //            .listRowBackground(Color.orange)
-                        //           .background(Color.purple)
-                        .font(.headline)
                     }
+                    
                 }
-            .listStyle(.grouped)
-            .navigationTitle(makeNavigationTitle(for: sectionListBy))
+                .padding(.trailing, 10)
+                .navigationBarHidden(true)
             }
         }
         .navigationViewStyle(StackNavigationViewStyle())
     }
     
-//    var body: some View {
-//        NavigationView {
-//            GeometryReader { geometry in
-//                ScrollView {
-//                    LazyVGrid(columns: columns) {
-//                        ForEach(bridgeStore.bridgeModels) { bridgeModel in
-//                            if let imageURL = bridgeModel.imageURL {
-//                                NavigationLink(destination: BridgeDetailsView(bridgeModel: bridgeModel)) {
-//                                    SinglePhotoView(imageURL: imageURL, bridgeModel: bridgeModel)
-//                                }
-//                            }
-//                        }
-//                    }
-//                }
-//                .navigationTitle("Bridge Photos")
-//            }
-//        }
-//        .navigationViewStyle(StackNavigationViewStyle())
-//    }
     private func makeNavigationTitle(for selectedSection: BridgeListViewModel.SectionListBy) -> String {
         var title = ""
         switch selectedSection {

--- a/PittsburghCityBridges/Views/BridgePhotosView.swift
+++ b/PittsburghCityBridges/Views/BridgePhotosView.swift
@@ -20,11 +20,8 @@ struct BridgePhotosView: View {
         //      UITableView.appearance().backgroundColor = .green
     }
     
-    var columns: [GridItem] = Array(repeating: .init(.flexible()), count: 1)
     var body: some View {
         NavigationView {
-            HStack {
-                Spacer()
                 ScrollView {
                     LazyVStack(spacing: 10, pinnedViews: [.sectionHeaders]) {
                         ForEach(bridgeListViewModel.sectionList(sectionListBy)) { bridgesSection in
@@ -42,32 +39,21 @@ struct BridgePhotosView: View {
                                 HStack {
                                     Spacer()
                                     Text("\(bridgesSection.sectionName)")
+                                        .foregroundColor(Color("SteelersGold"))
+
                                     Spacer()
                                 }
-                                .background(Color.black)
+                                .background(Color("SteelersBlack"))
+                       //         .background(Color.white)
                             }
                         }
                     }
                     
                 }
-                .padding(.trailing, 10)
+                .padding([.leading, .trailing], 10)
                 .navigationBarHidden(true)
-            }
         }
         .navigationViewStyle(StackNavigationViewStyle())
-    }
-    
-    private func makeNavigationTitle(for selectedSection: BridgeListViewModel.SectionListBy) -> String {
-        var title = ""
-        switch selectedSection {
-        case .name:
-            title = "by Name"
-        case .neighborhood:
-            title = "by Location"
-        case .year:
-            title = "by Year Built"
-        }
-        return title
     }
 }
 
@@ -90,16 +76,18 @@ struct SinglePhotoView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
             VStack {
-                Spacer()
                 HStack {
+                    Spacer()
                     Text("\(bridgeModel.name)")
                         .font(.caption)
-                        .foregroundColor(.primary)
-                        .background(.ultraThinMaterial)
+                        .foregroundColor(Color("SteelersGold"))
+                        .padding([.leading, .trailing], 5)
+                        .background(Color("SteelersBlack"))
                         .opacity(imageLoaded ? 1.0 : 0.0)
                     Spacer()
                 }
                 .padding(4)
+                Spacer()
             }
             BridgeImageLoadingProgressView(bridgeName: bridgeModel.name)
                 .opacity(imageLoaded ? 0.0 : 1.0)

--- a/PittsburghCityBridges/Views/BridgePhotosView.swift
+++ b/PittsburghCityBridges/Views/BridgePhotosView.swift
@@ -11,14 +11,14 @@ import os
 struct BridgePhotosView: View {
     @EnvironmentObject var bridgeStore: BridgeStore
     let logger =  Logger(subsystem: AppLogging.subsystem, category: "BridgePhotosView")
-    @State private var sectionListBy: BridgeListViewModel.SectionListBy = .neighborhood
+    private var sectionListBy: BridgeListViewModel.SectionListBy = .neighborhood
     private var bridgeListViewModel: BridgeListViewModel
 
-    init(_ bridgeListViewModel: BridgeListViewModel) {
+    init(_ bridgeListViewModel: BridgeListViewModel, sectionListBy: BridgeListViewModel.SectionListBy = .name) {
         self.bridgeListViewModel = bridgeListViewModel
+        self.sectionListBy = sectionListBy
         //      UITableView.appearance().backgroundColor = .green
     }
-    
     
     var columns: [GridItem] = Array(repeating: .init(.flexible()), count: 1)
     var body: some View {
@@ -48,31 +48,6 @@ struct BridgePhotosView: View {
             .listStyle(.grouped)
             .navigationTitle(makeNavigationTitle(for: sectionListBy))
             }
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Menu(content: {
-                        Button {
-                            self.sectionListBy = .neighborhood
-                        } label: {
-                            makeCheckedLabel("Sort by Location", selectedSection: .neighborhood)
-                        }
-                        Button {
-                            self.sectionListBy = .name
-                        } label: {
-                            makeCheckedLabel("Sort by Name", selectedSection: .name)
-                        }
-                        Button {
-                            self.sectionListBy = .year
-                        } label: {
-                            makeCheckedLabel("Sort by Year", selectedSection: .year)
-                        }
-                    },
-                         label: {
-                        Label("Sort", systemImage: "arrow.down")
-                            .labelStyle(.titleAndIcon)
-                    })
-                }
-            }
         }
         .navigationViewStyle(StackNavigationViewStyle())
     }
@@ -96,24 +71,15 @@ struct BridgePhotosView: View {
 //        }
 //        .navigationViewStyle(StackNavigationViewStyle())
 //    }
-    
-    private func makeCheckedLabel(_ name: String, selectedSection: BridgeListViewModel.SectionListBy) -> Label<Text, Image> {
-        if self.sectionListBy == selectedSection {
-            return Label(name, systemImage: "checkmark")
-        } else {
-            return Label(name, systemImage: "")
-        }
-    }
-    
     private func makeNavigationTitle(for selectedSection: BridgeListViewModel.SectionListBy) -> String {
         var title = ""
         switch selectedSection {
         case .name:
-            title = "Bridges by Name"
+            title = "by Name"
         case .neighborhood:
-            title = "Bridges by Location"
+            title = "by Location"
         case .year:
-            title = "Bridges by Year Built"
+            title = "by Year Built"
         }
         return title
     }

--- a/PittsburghCityBridges/Views/BridgeViewsView.swift
+++ b/PittsburghCityBridges/Views/BridgeViewsView.swift
@@ -24,13 +24,37 @@ struct BridgeViewsView: View {
         switch viewBridgeAs {
         case .list:
             VStack {
-                Text("Pittsburgh City Bridges")
+                menu()
                 BridgeListView(bridgeListViewModel)
             }
         case .photos:
             VStack {
-                Text("Pittsburgh City Bridges")
+                menu()
                 BridgePhotosView(bridgeListViewModel)
+            }
+        }
+    }
+    
+    private func menu() -> some View {
+        HStack {
+            ZStack {
+                HStack {
+                    Spacer()
+                    Text("Pittsburgh City Bridges")
+                    Spacer()
+                }
+                HStack {
+                    Menu("View" ,content: {
+                        Button("As List") {
+                            viewBridgeAs = .list
+                        }
+                        Button("As Photos") {
+                            viewBridgeAs = .photos
+                        }
+                    })
+                    .padding(.leading, 10)
+                    Spacer()
+                }
             }
         }
     }
@@ -38,8 +62,11 @@ struct BridgeViewsView: View {
 
 struct BridgeViewsView_Previews: PreviewProvider {
     static let bridgeStore = BridgeStore()
-
     static var previews: some View {
         BridgeViewsView(BridgeListViewModel(bridgeStore))
+            .environmentObject(bridgeStore)
+            .onAppear {
+                bridgeStore.preview()
+            }
     }
 }

--- a/PittsburghCityBridges/Views/BridgeViewsView.swift
+++ b/PittsburghCityBridges/Views/BridgeViewsView.swift
@@ -22,18 +22,23 @@ struct BridgeViewsView: View {
     }
     
     var body: some View {
-        switch viewBridgeAs {
-        case .list:
-            VStack {
-                menuBar()
-                BridgeListView(bridgeListViewModel, sectionListBy: sectionListBy)
-            }
-        case .photos:
-            VStack {
-                menuBar()
-                BridgePhotosView(bridgeListViewModel, sectionListBy: sectionListBy)
+        VStack {
+            switch viewBridgeAs {
+            case .list:
+                VStack {
+                    menuBar()
+                    BridgeListView(bridgeListViewModel, sectionListBy: sectionListBy)
+                }
+//                .transition(.opacity)
+            case .photos:
+                VStack {
+                    menuBar()
+                    BridgePhotosView(bridgeListViewModel, sectionListBy: sectionListBy)
+                }
             }
         }
+        .transition(.opacity)
+        .animation(.easeInOut, value: viewBridgeAs)
     }
     
     private func menuBar() -> some View {

--- a/PittsburghCityBridges/Views/BridgeViewsView.swift
+++ b/PittsburghCityBridges/Views/BridgeViewsView.swift
@@ -1,0 +1,45 @@
+//
+//  BridgeViewsView.swift
+//  PittsburghCityBridges
+//
+//  Created by MAKinney on 12/15/21.
+//
+
+import SwiftUI
+
+enum ViewBridgeAs {
+    case list
+    case photos
+}
+struct BridgeViewsView: View {
+    private var bridgeListViewModel: BridgeListViewModel
+    @State private var viewBridgeAs = ViewBridgeAs.list
+    
+    init(_ bridgeListViewModel: BridgeListViewModel) {
+        self.bridgeListViewModel = bridgeListViewModel
+        //      UITableView.appearance().backgroundColor = .green
+    }
+    
+    var body: some View {
+        switch viewBridgeAs {
+        case .list:
+            VStack {
+                Text("Pittsburgh City Bridges")
+                BridgeListView(bridgeListViewModel)
+            }
+        case .photos:
+            VStack {
+                Text("Pittsburgh City Bridges")
+                BridgePhotosView(bridgeListViewModel)
+            }
+        }
+    }
+}
+
+struct BridgeViewsView_Previews: PreviewProvider {
+    static let bridgeStore = BridgeStore()
+
+    static var previews: some View {
+        BridgeViewsView(BridgeListViewModel(bridgeStore))
+    }
+}

--- a/PittsburghCityBridges/Views/BridgeViewsView.swift
+++ b/PittsburghCityBridges/Views/BridgeViewsView.swift
@@ -13,7 +13,7 @@ enum ViewBridgeAs {
 }
 struct BridgeViewsView: View {
     private var bridgeListViewModel: BridgeListViewModel
-    @State private var viewBridgeAs = ViewBridgeAs.photos
+    @State private var viewBridgeAs = ViewBridgeAs.list
     @State private var sectionListBy: BridgeListViewModel.SectionListBy = .neighborhood
     
     init(_ bridgeListViewModel: BridgeListViewModel) {
@@ -42,14 +42,14 @@ struct BridgeViewsView: View {
     
     private func menuBar() -> some View {
         HStack {
-            viewSelectMenu()
+            viewModeButton()
                 .padding(.leading, 10)
             Spacer()
             switch sectionListBy {
             case .neighborhood:
                 Text("City Bridges by Neighborhood")
             case .name:
-                Text("City Bridges by Name")
+                Text("City Bridges by Names")
             case .year:
                 Text("City Bridges by Year Built")
             }
@@ -59,56 +59,51 @@ struct BridgeViewsView: View {
         }
     }
     
-    private func viewSelectMenu() -> some View {
-        Menu("View" ,content: {
-            Button {
-                viewBridgeAs = .list
-            } label: {
-                makeCheckedViewLabel("View as List", viewBridgeAs: .list)
-            }
-            Button {
+    private func viewModeButton() -> some View {
+        Button {
+            if viewBridgeAs == .list {
                 viewBridgeAs = .photos
-            } label: {
-                makeCheckedViewLabel("View as Photos", viewBridgeAs: .photos)
+            } else {
+                viewBridgeAs = .list
             }
-        })
+        } label: {
+            Label("Views", systemImage: (viewBridgeAs == .list) ?  "photo.fill.on.rectangle.fill" : "list.dash")
+                .labelStyle(.iconOnly)
+        }
+
     }
     
     private func sortMenu() -> some View {
-        Menu("Sort", content: {
-            Button {
-                sectionListBy = .neighborhood
-            } label: {
-                makeCheckedSortLabel("Sort by Neighborhood", selectedSection: .neighborhood)
-            }
+        Menu(content: {
             Button {
                 sectionListBy = .name
             } label: {
-                makeCheckedSortLabel("Sort by Name", selectedSection: .name)
+                makeCheckedSortLabel("Name Grouping", selectedSection: .name)
+            }
+            Button {
+                sectionListBy = .neighborhood
+            } label: {
+                makeCheckedSortLabel("Neighborhood Grouping", selectedSection: .neighborhood)
             }
             Button {
                 sectionListBy = .year
             } label: {
-                makeCheckedSortLabel("Sort by Year Built", selectedSection: .year)
+                makeCheckedSortLabel("Year Built Grouping", selectedSection: .year)
             }
+        }, label: {
+            Label("Sort", systemImage: "rectangle.split.3x3")
+                .labelStyle(.iconOnly)
         })
     }
     
     private func makeCheckedSortLabel(_ name: String, selectedSection: BridgeListViewModel.SectionListBy) -> Label<Text, Image> {
         if self.sectionListBy == selectedSection {
-            return Label(name, systemImage: "checkmark")
+            return Label(name, systemImage: "checkmark.square.fill")
         } else {
-            return Label(name, systemImage: "")
+            return Label(name, systemImage: "square")
         }
     }
     
-    private func makeCheckedViewLabel(_ name: String, viewBridgeAs: ViewBridgeAs) -> Label<Text, Image> {
-        if self.viewBridgeAs == viewBridgeAs {
-            return Label(name, systemImage: "checkmark")
-        } else {
-            return Label(name, systemImage: "")
-        }
-    }
 }
 
 struct BridgeViewsView_Previews: PreviewProvider {

--- a/PittsburghCityBridges/Views/BridgeViewsView.swift
+++ b/PittsburghCityBridges/Views/BridgeViewsView.swift
@@ -78,17 +78,17 @@ struct BridgeViewsView: View {
             Button {
                 sectionListBy = .name
             } label: {
-                makeCheckedSortLabel("Name Grouping", selectedSection: .name)
+                makeCheckedSortLabel("By Names", selectedSection: .name)
             }
             Button {
                 sectionListBy = .neighborhood
             } label: {
-                makeCheckedSortLabel("Neighborhood Grouping", selectedSection: .neighborhood)
+                makeCheckedSortLabel("By Neighborhoods", selectedSection: .neighborhood)
             }
             Button {
                 sectionListBy = .year
             } label: {
-                makeCheckedSortLabel("Year Built Grouping", selectedSection: .year)
+                makeCheckedSortLabel("By Year Built", selectedSection: .year)
             }
         }, label: {
             Label("Sort", systemImage: "rectangle.split.3x3")

--- a/PittsburghCityBridges/Views/BridgeViewsView.swift
+++ b/PittsburghCityBridges/Views/BridgeViewsView.swift
@@ -13,7 +13,7 @@ enum ViewBridgeAs {
 }
 struct BridgeViewsView: View {
     private var bridgeListViewModel: BridgeListViewModel
-    @State private var viewBridgeAs = ViewBridgeAs.list
+    @State private var viewBridgeAs = ViewBridgeAs.photos
     @State private var sectionListBy: BridgeListViewModel.SectionListBy = .neighborhood
     
     init(_ bridgeListViewModel: BridgeListViewModel) {
@@ -29,7 +29,6 @@ struct BridgeViewsView: View {
                     menuBar()
                     BridgeListView(bridgeListViewModel, sectionListBy: sectionListBy)
                 }
-//                .transition(.opacity)
             case .photos:
                 VStack {
                     menuBar()
@@ -43,23 +42,34 @@ struct BridgeViewsView: View {
     
     private func menuBar() -> some View {
         HStack {
-            viewMenu()
+            viewSelectMenu()
                 .padding(.leading, 10)
             Spacer()
-            Text("Pittsburgh City Bridges")
+            switch sectionListBy {
+            case .neighborhood:
+                Text("City Bridges by Neighborhood")
+            case .name:
+                Text("City Bridges by Name")
+            case .year:
+                Text("City Bridges by Year Built")
+            }
             Spacer()
             sortMenu()
                 .padding(.trailing, 10)
         }
     }
     
-    private func viewMenu() -> some View {
+    private func viewSelectMenu() -> some View {
         Menu("View" ,content: {
-            Button("As List") {
+            Button {
                 viewBridgeAs = .list
+            } label: {
+                makeCheckedViewLabel("View as List", viewBridgeAs: .list)
             }
-            Button("As Photos") {
+            Button {
                 viewBridgeAs = .photos
+            } label: {
+                makeCheckedViewLabel("View as Photos", viewBridgeAs: .photos)
             }
         })
     }
@@ -67,25 +77,33 @@ struct BridgeViewsView: View {
     private func sortMenu() -> some View {
         Menu("Sort", content: {
             Button {
-                self.sectionListBy = .neighborhood
+                sectionListBy = .neighborhood
             } label: {
-                makeCheckedLabel("Sort by Location", selectedSection: .neighborhood)
+                makeCheckedSortLabel("Sort by Neighborhood", selectedSection: .neighborhood)
             }
             Button {
-                self.sectionListBy = .name
+                sectionListBy = .name
             } label: {
-                makeCheckedLabel("Sort by Name", selectedSection: .name)
+                makeCheckedSortLabel("Sort by Name", selectedSection: .name)
             }
             Button {
-                self.sectionListBy = .year
+                sectionListBy = .year
             } label: {
-                makeCheckedLabel("Sort by Year", selectedSection: .year)
+                makeCheckedSortLabel("Sort by Year Built", selectedSection: .year)
             }
         })
     }
     
-    private func makeCheckedLabel(_ name: String, selectedSection: BridgeListViewModel.SectionListBy) -> Label<Text, Image> {
+    private func makeCheckedSortLabel(_ name: String, selectedSection: BridgeListViewModel.SectionListBy) -> Label<Text, Image> {
         if self.sectionListBy == selectedSection {
+            return Label(name, systemImage: "checkmark")
+        } else {
+            return Label(name, systemImage: "")
+        }
+    }
+    
+    private func makeCheckedViewLabel(_ name: String, viewBridgeAs: ViewBridgeAs) -> Label<Text, Image> {
+        if self.viewBridgeAs == viewBridgeAs {
             return Label(name, systemImage: "checkmark")
         } else {
             return Label(name, systemImage: "")

--- a/PittsburghCityBridges/Views/BridgeViewsView.swift
+++ b/PittsburghCityBridges/Views/BridgeViewsView.swift
@@ -14,6 +14,7 @@ enum ViewBridgeAs {
 struct BridgeViewsView: View {
     private var bridgeListViewModel: BridgeListViewModel
     @State private var viewBridgeAs = ViewBridgeAs.list
+    @State private var sectionListBy: BridgeListViewModel.SectionListBy = .neighborhood
     
     init(_ bridgeListViewModel: BridgeListViewModel) {
         self.bridgeListViewModel = bridgeListViewModel
@@ -24,38 +25,65 @@ struct BridgeViewsView: View {
         switch viewBridgeAs {
         case .list:
             VStack {
-                menu()
-                BridgeListView(bridgeListViewModel)
+                menuBar()
+                BridgeListView(bridgeListViewModel, sectionListBy: sectionListBy)
             }
         case .photos:
             VStack {
-                menu()
-                BridgePhotosView(bridgeListViewModel)
+                menuBar()
+                BridgePhotosView(bridgeListViewModel, sectionListBy: sectionListBy)
             }
         }
     }
     
-    private func menu() -> some View {
+    private func menuBar() -> some View {
         HStack {
-            ZStack {
-                HStack {
-                    Spacer()
-                    Text("Pittsburgh City Bridges")
-                    Spacer()
-                }
-                HStack {
-                    Menu("View" ,content: {
-                        Button("As List") {
-                            viewBridgeAs = .list
-                        }
-                        Button("As Photos") {
-                            viewBridgeAs = .photos
-                        }
-                    })
-                    .padding(.leading, 10)
-                    Spacer()
-                }
+            viewMenu()
+                .padding(.leading, 10)
+            Spacer()
+            Text("Pittsburgh City Bridges")
+            Spacer()
+            sortMenu()
+                .padding(.trailing, 10)
+        }
+    }
+    
+    private func viewMenu() -> some View {
+        Menu("View" ,content: {
+            Button("As List") {
+                viewBridgeAs = .list
             }
+            Button("As Photos") {
+                viewBridgeAs = .photos
+            }
+        })
+    }
+    
+    private func sortMenu() -> some View {
+        Menu("Sort", content: {
+            Button {
+                self.sectionListBy = .neighborhood
+            } label: {
+                makeCheckedLabel("Sort by Location", selectedSection: .neighborhood)
+            }
+            Button {
+                self.sectionListBy = .name
+            } label: {
+                makeCheckedLabel("Sort by Name", selectedSection: .name)
+            }
+            Button {
+                self.sectionListBy = .year
+            } label: {
+                makeCheckedLabel("Sort by Year", selectedSection: .year)
+            }
+        })
+    }
+    
+    private func makeCheckedLabel(_ name: String, selectedSection: BridgeListViewModel.SectionListBy) -> Label<Text, Image> {
+        if self.sectionListBy == selectedSection {
+            return Label(name, systemImage: "checkmark")
+        } else {
+            return Label(name, systemImage: "")
         }
     }
 }

--- a/PittsburghCityBridges/Views/ContentView.swift
+++ b/PittsburghCityBridges/Views/ContentView.swift
@@ -12,14 +12,14 @@ struct ContentView: View {
 
     var body: some View {
         TabView {
-            BridgeListView(BridgeListViewModel(bridgeStore))
+            BridgeViewsView(BridgeListViewModel(bridgeStore))
                 .tabItem {
-                    Label("Bridges", systemImage: "list.dash")
+                    Label("Bridges", systemImage: "waveform")
                 }
-            BridgePhotosView(BridgeListViewModel(bridgeStore))
-                .tabItem {
-                    Label("Photos", systemImage: "photo")
-                }
+//            BridgePhotosView(BridgeListViewModel(bridgeStore))
+//                .tabItem {
+//                    Label("Photos", systemImage: "photo")
+//                }
             BridgeMapView()
                 .tabItem {
                     Label("Map", systemImage: "map")


### PR DESCRIPTION
Nice View refactor that affected Tab Bar. Instead of Tabs for viewing bridge as a list and a tab for viewing as photos, now combine to a single tab for viewing the bridges. And the view for that tab (BridgeViewViews), has menu button to toggle between list and photo views.  Much cleaner and easier to use

Also refactored the list and photo views to have several features including sticky section headers, better layouts, eliminate of navigation title from individual views. Instead titles are in the main views, the bridge views view.  

Some color changes to spruce things up, will revise when entire app is styled later.  This is the approach I'm taking, function first, then appearance.  As the UI is changing during development 