### PR TITLE
Tab view refactor to list and photos

### DIFF
--- a/PittsburghCityBridges.xcodeproj/project.pbxproj
+++ b/PittsburghCityBridges.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		248FC58A270276EE00BE168F /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 248FC589270276EE00BE168F /* Preview Assets.xcassets */; };
 		248FC58C270276EE00BE168F /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 248FC58B270276EE00BE168F /* Persistence.swift */; };
 		248FC59A270278F100BE168F /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 248FC599270278F100BE168F /* CloudKit.framework */; };
+		249C7D5B277E52D700D72DA4 /* BridgeMenuBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249C7D5A277E52D700D72DA4 /* BridgeMenuBar.swift */; };
 		24B3FE8F272225B8004B93A6 /* MapExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B3FE8E272225B8004B93A6 /* MapExtensions.swift */; };
 		24B3FE912722356A004B93A6 /* DirectionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B3FE902722356A004B93A6 /* DirectionsProvider.swift */; };
 		24C65481276A855B006363B8 /* BridgeViewsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C65480276A855A006363B8 /* BridgeViewsView.swift */; };
@@ -79,6 +80,7 @@
 		248FC58B270276EE00BE168F /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
 		248FC597270278E000BE168F /* PittsburghCityBridges.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PittsburghCityBridges.entitlements; sourceTree = "<group>"; };
 		248FC599270278F100BE168F /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
+		249C7D5A277E52D700D72DA4 /* BridgeMenuBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeMenuBar.swift; sourceTree = "<group>"; };
 		24B3FE8E272225B8004B93A6 /* MapExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapExtensions.swift; sourceTree = "<group>"; };
 		24B3FE902722356A004B93A6 /* DirectionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionsProvider.swift; sourceTree = "<group>"; };
 		24C65480276A855A006363B8 /* BridgeViewsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeViewsView.swift; sourceTree = "<group>"; };
@@ -156,6 +158,7 @@
 				2410128A2713787200FE7DEC /* BridgePhotosView.swift */,
 				248FC584270276EA00BE168F /* CloudKitContentView.swift */,
 				2410128C2713855400FE7DEC /* ContentView.swift */,
+				249C7D5A277E52D700D72DA4 /* BridgeMenuBar.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -341,6 +344,7 @@
 				244E9C91273ABF2A00605134 /* BridgeListViewModel.swift in Sources */,
 				24808FD3274D443D00FF131C /* ViewExtensions.swift in Sources */,
 				241012872713784D00FE7DEC /* BridgeListView.swift in Sources */,
+				249C7D5B277E52D700D72DA4 /* BridgeMenuBar.swift in Sources */,
 				2419B8C42721D64E00BFE3D8 /* LocationService.swift in Sources */,
 				24C654852772BF55006363B8 /* AppColors.swift in Sources */,
 				24808FDC275A6D9B00FF131C /* BridgeImageSystem.swift in Sources */,

--- a/PittsburghCityBridges.xcodeproj/project.pbxproj
+++ b/PittsburghCityBridges.xcodeproj/project.pbxproj
@@ -38,7 +38,8 @@
 		248FC58A270276EE00BE168F /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 248FC589270276EE00BE168F /* Preview Assets.xcassets */; };
 		248FC58C270276EE00BE168F /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 248FC58B270276EE00BE168F /* Persistence.swift */; };
 		248FC59A270278F100BE168F /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 248FC599270278F100BE168F /* CloudKit.framework */; };
-		249C7D5B277E52D700D72DA4 /* BridgeMenuBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249C7D5A277E52D700D72DA4 /* BridgeMenuBar.swift */; };
+		249C7D5B277E52D700D72DA4 /* HeaderToolBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249C7D5A277E52D700D72DA4 /* HeaderToolBar.swift */; };
+		249C7D5D277F609600D72DA4 /* TitleHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249C7D5C277F609600D72DA4 /* TitleHeader.swift */; };
 		24B3FE8F272225B8004B93A6 /* MapExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B3FE8E272225B8004B93A6 /* MapExtensions.swift */; };
 		24B3FE912722356A004B93A6 /* DirectionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B3FE902722356A004B93A6 /* DirectionsProvider.swift */; };
 		24C65481276A855B006363B8 /* BridgeViewsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C65480276A855A006363B8 /* BridgeViewsView.swift */; };
@@ -80,7 +81,8 @@
 		248FC58B270276EE00BE168F /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
 		248FC597270278E000BE168F /* PittsburghCityBridges.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PittsburghCityBridges.entitlements; sourceTree = "<group>"; };
 		248FC599270278F100BE168F /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
-		249C7D5A277E52D700D72DA4 /* BridgeMenuBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeMenuBar.swift; sourceTree = "<group>"; };
+		249C7D5A277E52D700D72DA4 /* HeaderToolBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderToolBar.swift; sourceTree = "<group>"; };
+		249C7D5C277F609600D72DA4 /* TitleHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleHeader.swift; sourceTree = "<group>"; };
 		24B3FE8E272225B8004B93A6 /* MapExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapExtensions.swift; sourceTree = "<group>"; };
 		24B3FE902722356A004B93A6 /* DirectionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionsProvider.swift; sourceTree = "<group>"; };
 		24C65480276A855A006363B8 /* BridgeViewsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeViewsView.swift; sourceTree = "<group>"; };
@@ -158,7 +160,8 @@
 				2410128A2713787200FE7DEC /* BridgePhotosView.swift */,
 				248FC584270276EA00BE168F /* CloudKitContentView.swift */,
 				2410128C2713855400FE7DEC /* ContentView.swift */,
-				249C7D5A277E52D700D72DA4 /* BridgeMenuBar.swift */,
+				249C7D5A277E52D700D72DA4 /* HeaderToolBar.swift */,
+				249C7D5C277F609600D72DA4 /* TitleHeader.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -342,9 +345,10 @@
 				244A747427187D1200284608 /* BridgeModel.swift in Sources */,
 				248FC583270276EA00BE168F /* PittsburghCityBridgesApp.swift in Sources */,
 				244E9C91273ABF2A00605134 /* BridgeListViewModel.swift in Sources */,
+				249C7D5D277F609600D72DA4 /* TitleHeader.swift in Sources */,
 				24808FD3274D443D00FF131C /* ViewExtensions.swift in Sources */,
 				241012872713784D00FE7DEC /* BridgeListView.swift in Sources */,
-				249C7D5B277E52D700D72DA4 /* BridgeMenuBar.swift in Sources */,
+				249C7D5B277E52D700D72DA4 /* HeaderToolBar.swift in Sources */,
 				2419B8C42721D64E00BFE3D8 /* LocationService.swift in Sources */,
 				24C654852772BF55006363B8 /* AppColors.swift in Sources */,
 				24808FDC275A6D9B00FF131C /* BridgeImageSystem.swift in Sources */,

--- a/PittsburghCityBridges/Appearance/AppColors.swift
+++ b/PittsburghCityBridges/Appearance/AppColors.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import UIKit
 
 extension Color {
+    static let pbAccent = Color(light: Asset.bridgeBlackA, dark: Asset.bridgeBrownC)
     static let pbTextFgndBrown = Color(light: Asset.bridgeBlackA, dark: Asset.bridgeBrownA)
     static let pbTextBgndBrown = Color(light: Asset.bridgeBrownA, dark: Asset.bridgeBlackA)
     static let pbTextFgndGreen = Color(light: Asset.bridgeBlackA, dark: Asset.bridgeGreenA)

--- a/PittsburghCityBridges/Appearance/PBColorPalate.swift
+++ b/PittsburghCityBridges/Appearance/PBColorPalate.swift
@@ -21,10 +21,10 @@ class PBColorPalateSource {
     
     init() {
         palates.append(PBColorPalate(textFgnd:.pbTextFgndYellow, textBgnd: .pbTextBgndYellow))
-        palates.append(PBColorPalate(textFgnd:.pbTextFgndGreen, textBgnd: .pbTextBgndGreen))
-        palates.append(PBColorPalate(textFgnd:.pbTextFgndBrown, textBgnd: .pbTextBgndBrown))
+   //     palates.append(PBColorPalate(textFgnd:.pbTextFgndGreen, textBgnd: .pbTextBgndGreen))
+  //      palates.append(PBColorPalate(textFgnd:.pbTextFgndBrown, textBgnd: .pbTextBgndBrown))
   //      palates.append(PBColorPalate())
-   //     palates.append(PBColorPalate(textFgnd:.pbTextFgndConcrete, textBgnd: .pbTextBgndConcrete))
+        palates.append(PBColorPalate(textFgnd:.pbTextFgndConcrete, textBgnd: .pbTextBgndConcrete))
     }
     
     func next() -> PBColorPalate {

--- a/PittsburghCityBridges/Appearance/PBColorPalate.swift
+++ b/PittsburghCityBridges/Appearance/PBColorPalate.swift
@@ -11,6 +11,8 @@ import SwiftUI
 struct PBColorPalate {
     var textFgnd: Color = Color(uiColor: UIColor.label)
     var textBgnd: Color = Color(UIColor.secondarySystemBackground)
+    var titleTextFgnd: Color = .pbTitleTextFgnd
+    var titleTextBgnd: Color = .pbTitleTextBgnd
 }
 
 class PBColorPalateSource {

--- a/PittsburghCityBridges/Appearance/PBColorPalate.swift
+++ b/PittsburghCityBridges/Appearance/PBColorPalate.swift
@@ -19,8 +19,8 @@ class PBColorPalateSource {
     
     init() {
         palates.append(PBColorPalate(textFgnd:.pbTextFgndYellow, textBgnd: .pbTextBgndYellow))
-   //     palates.append(PBColorPalate(textFgnd:.pbTextFgndGreen, textBgnd: .pbTextBgndGreen))
- //       palates.append(PBColorPalate(textFgnd:.pbTextFgndBrown, textBgnd: .pbTextBgndBrown))
+        palates.append(PBColorPalate(textFgnd:.pbTextFgndGreen, textBgnd: .pbTextBgndGreen))
+        palates.append(PBColorPalate(textFgnd:.pbTextFgndBrown, textBgnd: .pbTextBgndBrown))
   //      palates.append(PBColorPalate())
    //     palates.append(PBColorPalate(textFgnd:.pbTextFgndConcrete, textBgnd: .pbTextBgndConcrete))
     }

--- a/PittsburghCityBridges/Appearance/PBColorPalate.swift
+++ b/PittsburghCityBridges/Appearance/PBColorPalate.swift
@@ -19,10 +19,10 @@ class PBColorPalateSource {
     
     init() {
         palates.append(PBColorPalate(textFgnd:.pbTextFgndYellow, textBgnd: .pbTextBgndYellow))
-        palates.append(PBColorPalate(textFgnd:.pbTextFgndGreen, textBgnd: .pbTextBgndGreen))
-        palates.append(PBColorPalate(textFgnd:.pbTextFgndBrown, textBgnd: .pbTextBgndBrown))
-//        palates.append(PBColorPalate())
-        palates.append(PBColorPalate(textFgnd:.pbTextFgndConcrete, textBgnd: .pbTextBgndConcrete))
+   //     palates.append(PBColorPalate(textFgnd:.pbTextFgndGreen, textBgnd: .pbTextBgndGreen))
+ //       palates.append(PBColorPalate(textFgnd:.pbTextFgndBrown, textBgnd: .pbTextBgndBrown))
+  //      palates.append(PBColorPalate())
+   //     palates.append(PBColorPalate(textFgnd:.pbTextFgndConcrete, textBgnd: .pbTextBgndConcrete))
     }
     
     func next() -> PBColorPalate {

--- a/PittsburghCityBridges/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/PittsburghCityBridges/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -5,8 +5,8 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.575",
-          "green" : "0.329",
+          "blue" : "0.219",
+          "green" : "0.413",
           "red" : "0.000"
         }
       },
@@ -23,8 +23,8 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "0.590",
+          "blue" : "0.000",
+          "green" : "0.560",
           "red" : "0.000"
         }
       },

--- a/PittsburghCityBridges/Assets.xcassets/accent.colorset/Contents.json
+++ b/PittsburghCityBridges/Assets.xcassets/accent.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.575",
-          "green" : "0.329",
-          "red" : "0.000"
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"
@@ -24,8 +24,8 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "1.000",
-          "green" : "0.590",
-          "red" : "0.000"
+          "green" : "1.000",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/PittsburghCityBridges/Assets.xcassets/bridgeBrownC.colorset/Contents.json
+++ b/PittsburghCityBridges/Assets.xcassets/bridgeBrownC.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0",
-          "green" : "50",
-          "red" : "111"
+          "blue" : "0x00",
+          "green" : "0x32",
+          "red" : "0x71"
         }
       },
       "idiom" : "universal"

--- a/PittsburghCityBridges/Models/BridgeListViewModel.swift
+++ b/PittsburghCityBridges/Models/BridgeListViewModel.swift
@@ -20,7 +20,7 @@ class BridgeListViewModel {
         var bridgeModels: [BridgeModel]
         var pbColorPalate = PBColorPalate()
     }
-    enum SectionListBy: Int {
+    enum BridgeInfoGrouping: Int {
         case name
         case neighborhood
         case year
@@ -36,8 +36,8 @@ class BridgeListViewModel {
     }
     
     @MainActor
-    func sectionList(_ sectionListBy: SectionListBy) -> [Section] {
-        switch sectionListBy {
+    func sections(groupedBy: BridgeInfoGrouping) -> [Section] {
+        switch groupedBy {
         case .name:
             nameSectionCache = nameSectionCache.isEmpty ? sectionByName() : nameSectionCache
             return nameSectionCache

--- a/PittsburghCityBridges/Views/BridgeListView.swift
+++ b/PittsburghCityBridges/Views/BridgeListView.swift
@@ -33,11 +33,10 @@ struct BridgeListView: View {
                                 ForEach(bridgesSection.bridgeModels) { bridgeModel in
                                     NavigationLink(destination: BridgeDetailsView(bridgeModel: bridgeModel, pbColorPalate: bridgesSection.pbColorPalate)) {
                                         BridgeListRow(bridgeModel: bridgeModel)
-                                            .padding([.leading])
+                                            .padding([.leading, .trailing])
                                     }
                                     Divider()
                                 }
-                                .font(.body)
                             } header: {
                                 HStack {
                                     sectionLabel(bridgesSection.sectionName, bridgeInfoGrouping)

--- a/PittsburghCityBridges/Views/BridgeListView.swift
+++ b/PittsburghCityBridges/Views/BridgeListView.swift
@@ -108,8 +108,8 @@ extension BridgeListView {
                 makeCheckedSortLabel("By Year Built", selectedSection: .year)
             }
         }, label: {
-            Label("Sort", systemImage: "rectangle.split.3x3")
-                .labelStyle(.iconOnly)
+            Label("Sort", systemImage: "arrow.up.arrow.down.square")
+                .labelStyle(.titleAndIcon)
         })
     }
     

--- a/PittsburghCityBridges/Views/BridgeListView.swift
+++ b/PittsburghCityBridges/Views/BridgeListView.swift
@@ -10,12 +10,12 @@ import SwiftUI
 struct BridgeListView: View {
     @EnvironmentObject var bridgeStore: BridgeStore
     @State private var showSheet = false
-    @AppStorage("brigeInfoGrouping") private var brigeInfoGrouping = BridgeListViewModel.BridgeInfoGrouping.neighborhood
+    @AppStorage("bridgeListView.bridgeInfoGrouping") private var bridgeInfoGrouping = BridgeListViewModel.BridgeInfoGrouping.neighborhood
     private var bridgeListViewModel: BridgeListViewModel
     
-    init(_ bridgeListViewModel: BridgeListViewModel, brigeInfoGrouping: BridgeListViewModel.BridgeInfoGrouping) {
+    init(_ bridgeListViewModel: BridgeListViewModel, bridgeInfoGrouping: BridgeListViewModel.BridgeInfoGrouping) {
         self.bridgeListViewModel = bridgeListViewModel
-        self.brigeInfoGrouping = brigeInfoGrouping
+        self.bridgeInfoGrouping = bridgeInfoGrouping
     }
     
     init(_ bridgeListViewModel: BridgeListViewModel) {
@@ -28,7 +28,7 @@ struct BridgeListView: View {
             menuBar()
             ScrollView {
                 LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
-                    ForEach(bridgeListViewModel.sections(groupedBy: brigeInfoGrouping)) { bridgesSection in
+                    ForEach(bridgeListViewModel.sections(groupedBy: bridgeInfoGrouping)) { bridgesSection in
                         Section {
                             ForEach(bridgesSection.bridgeModels) { bridgeModel in
                                 NavigationLink(destination: BridgeDetailsView(bridgeModel: bridgeModel, pbColorPalate: bridgesSection.pbColorPalate)) {
@@ -40,7 +40,7 @@ struct BridgeListView: View {
                             .font(.body)
                         } header: {
                             HStack {
-                                sectionLabel(bridgesSection.sectionName, brigeInfoGrouping)
+                                sectionLabel(bridgesSection.sectionName, bridgeInfoGrouping)
                                     .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
                                     .font(.title3)
                                     .padding([.leading])
@@ -51,9 +51,9 @@ struct BridgeListView: View {
                         .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
                         .background(bridgesSection.pbColorPalate.textBgnd)
                     }
-                    }
+                }
             }
-        }
+            }
             .background(Color.black)
             .navigationBarHidden(true)
         }
@@ -73,6 +73,10 @@ struct BridgeListView: View {
         }
     }
     
+}
+
+extension BridgeListView {
+    
     private func menuBar() -> some View {
         HStack {
             Spacer()
@@ -89,17 +93,17 @@ struct BridgeListView: View {
     private func sortMenu() -> some View {
         Menu(content: {
             Button {
-                brigeInfoGrouping = .name
+                bridgeInfoGrouping = .name
             } label: {
                 makeCheckedSortLabel("By Names", selectedSection: .name)
             }
             Button {
-                brigeInfoGrouping = .neighborhood
+                bridgeInfoGrouping = .neighborhood
             } label: {
                 makeCheckedSortLabel("By Neighborhoods", selectedSection: .neighborhood)
             }
             Button {
-                brigeInfoGrouping = .year
+                bridgeInfoGrouping = .year
             } label: {
                 makeCheckedSortLabel("By Year Built", selectedSection: .year)
             }
@@ -110,13 +114,12 @@ struct BridgeListView: View {
     }
     
     private func makeCheckedSortLabel(_ name: String, selectedSection: BridgeListViewModel.BridgeInfoGrouping) -> Label<Text, Image> {
-        if self.brigeInfoGrouping == selectedSection {
+        if self.bridgeInfoGrouping == selectedSection {
             return Label(name, systemImage: "checkmark.square.fill")
         } else {
             return Label(name, systemImage: "square")
         }
     }
-    
 }
 
 struct BridgeListView_Previews: PreviewProvider {

--- a/PittsburghCityBridges/Views/BridgeListView.swift
+++ b/PittsburghCityBridges/Views/BridgeListView.swift
@@ -24,8 +24,9 @@ struct BridgeListView: View {
     
     var body: some View {
         NavigationView {
-            VStack {
-                BridgeMenuBar(bridgeInfoGrouping: $bridgeInfoGrouping)
+            VStack(spacing: 0) {
+                TitleHeader()
+                HeaderToolBar(bridgeInfoGrouping: $bridgeInfoGrouping)
                 ScrollView {
                     LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
                         ForEach(bridgeListViewModel.sections(groupedBy: bridgeInfoGrouping)) { bridgesSection in
@@ -43,6 +44,8 @@ struct BridgeListView: View {
                                         .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
                                         .font(.title3)
                                         .padding([.leading])
+                                        .padding([.top], 10)
+                                        .padding([.bottom], 5)
                                     Spacer()
                                 }
                             }
@@ -63,11 +66,11 @@ struct BridgeListView: View {
     private func sectionLabel(_ sectionName: String, _ sectionListby: BridgeListViewModel.BridgeInfoGrouping) -> some View {
         switch sectionListby {
         case .neighborhood:
-            Text("\(sectionName) Neighborhood")
+            Text("\(sectionName)")
         case .name:
-            Text("Starting with \(sectionName)")
+            Text("\(sectionName)")
         case .year:
-            Text("Built in \(sectionName)")
+            Text("\(sectionName)")
         }
     }
 }

--- a/PittsburghCityBridges/Views/BridgeListView.swift
+++ b/PittsburghCityBridges/Views/BridgeListView.swift
@@ -25,34 +25,34 @@ struct BridgeListView: View {
     var body: some View {
         NavigationView {
             VStack {
-            menuBar()
-            ScrollView {
-                LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
-                    ForEach(bridgeListViewModel.sections(groupedBy: bridgeInfoGrouping)) { bridgesSection in
-                        Section {
-                            ForEach(bridgesSection.bridgeModels) { bridgeModel in
-                                NavigationLink(destination: BridgeDetailsView(bridgeModel: bridgeModel, pbColorPalate: bridgesSection.pbColorPalate)) {
-                                    BridgeListRow(bridgeModel: bridgeModel)
-                                        .padding([.leading])
+                BridgeMenuBar(bridgeInfoGrouping: $bridgeInfoGrouping)
+                ScrollView {
+                    LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+                        ForEach(bridgeListViewModel.sections(groupedBy: bridgeInfoGrouping)) { bridgesSection in
+                            Section {
+                                ForEach(bridgesSection.bridgeModels) { bridgeModel in
+                                    NavigationLink(destination: BridgeDetailsView(bridgeModel: bridgeModel, pbColorPalate: bridgesSection.pbColorPalate)) {
+                                        BridgeListRow(bridgeModel: bridgeModel)
+                                            .padding([.leading])
+                                    }
+                                    Divider()
                                 }
-                                Divider()
+                                .font(.body)
+                            } header: {
+                                HStack {
+                                    sectionLabel(bridgesSection.sectionName, bridgeInfoGrouping)
+                                        .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
+                                        .font(.title3)
+                                        .padding([.leading])
+                                    Spacer()
+                                }
                             }
-                            .font(.body)
-                        } header: {
-                            HStack {
-                                sectionLabel(bridgesSection.sectionName, bridgeInfoGrouping)
-                                    .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
-                                    .font(.title3)
-                                    .padding([.leading])
-                                Spacer()
-                            }
+                            .font(.headline)
+                            .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
+                            .background(bridgesSection.pbColorPalate.textBgnd)
                         }
-                        .font(.headline)
-                        .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
-                        .background(bridgesSection.pbColorPalate.textBgnd)
                     }
                 }
-            }
             }
             .background(Color.black)
             .navigationBarHidden(true)
@@ -62,7 +62,6 @@ struct BridgeListView: View {
     
     @ViewBuilder
     private func sectionLabel(_ sectionName: String, _ sectionListby: BridgeListViewModel.BridgeInfoGrouping) -> some View {
-        
         switch sectionListby {
         case .neighborhood:
             Text("\(sectionName) Neighborhood")
@@ -70,54 +69,6 @@ struct BridgeListView: View {
             Text("Starting with \(sectionName)")
         case .year:
             Text("Built in \(sectionName)")
-        }
-    }
-    
-}
-
-extension BridgeListView {
-    
-    private func menuBar() -> some View {
-        HStack {
-            Spacer()
-            Text("Pittsburgh Bridges")
-                .foregroundColor(.pbTitleTextFgnd)
-                .font(.title)
-            Spacer()
-            sortMenu()
-                .padding(.trailing, 10)
-        }
-        .background(Color.pbTitleTextBgnd)
-    }
-    
-    private func sortMenu() -> some View {
-        Menu(content: {
-            Button {
-                bridgeInfoGrouping = .name
-            } label: {
-                makeCheckedSortLabel("By Names", selectedSection: .name)
-            }
-            Button {
-                bridgeInfoGrouping = .neighborhood
-            } label: {
-                makeCheckedSortLabel("By Neighborhoods", selectedSection: .neighborhood)
-            }
-            Button {
-                bridgeInfoGrouping = .year
-            } label: {
-                makeCheckedSortLabel("By Year Built", selectedSection: .year)
-            }
-        }, label: {
-            Label("Sort", systemImage: "arrow.up.arrow.down.square")
-                .labelStyle(.titleAndIcon)
-        })
-    }
-    
-    private func makeCheckedSortLabel(_ name: String, selectedSection: BridgeListViewModel.BridgeInfoGrouping) -> Label<Text, Image> {
-        if self.bridgeInfoGrouping == selectedSection {
-            return Label(name, systemImage: "checkmark.square.fill")
-        } else {
-            return Label(name, systemImage: "square")
         }
     }
 }

--- a/PittsburghCityBridges/Views/BridgeListView.swift
+++ b/PittsburghCityBridges/Views/BridgeListView.swift
@@ -10,61 +10,58 @@ import SwiftUI
 struct BridgeListView: View {
     @EnvironmentObject var bridgeStore: BridgeStore
     @State private var showSheet = false
-    private var sectionListBy: BridgeListViewModel.SectionListBy = .neighborhood
+    @AppStorage("brigeInfoGrouping") private var brigeInfoGrouping = BridgeListViewModel.BridgeInfoGrouping.neighborhood
     private var bridgeListViewModel: BridgeListViewModel
     
-    init(_ bridgeListViewModel: BridgeListViewModel, sectionListBy: BridgeListViewModel.SectionListBy = .name) {
+    init(_ bridgeListViewModel: BridgeListViewModel, brigeInfoGrouping: BridgeListViewModel.BridgeInfoGrouping) {
         self.bridgeListViewModel = bridgeListViewModel
-        self.sectionListBy = sectionListBy
-        //      UITableView.appearance().backgroundColor = .green
+        self.brigeInfoGrouping = brigeInfoGrouping
     }
     
+    init(_ bridgeListViewModel: BridgeListViewModel) {
+        self.bridgeListViewModel = bridgeListViewModel
+    }
     
     var body: some View {
         NavigationView {
+            VStack {
+            menuBar()
             ScrollView {
                 LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
-                    ForEach(bridgeListViewModel.sectionList(sectionListBy)) { bridgesSection in
+                    ForEach(bridgeListViewModel.sections(groupedBy: brigeInfoGrouping)) { bridgesSection in
                         Section {
                             ForEach(bridgesSection.bridgeModels) { bridgeModel in
                                 NavigationLink(destination: BridgeDetailsView(bridgeModel: bridgeModel, pbColorPalate: bridgesSection.pbColorPalate)) {
                                     BridgeListRow(bridgeModel: bridgeModel)
                                         .padding([.leading])
-                               //         .padding()
-                                    //    .padding([.trailing, .leading], 10)
-                                    //    .padding([.top], 10)
                                 }
                                 Divider()
                             }
                             .font(.body)
                         } header: {
                             HStack {
-                                sectionLabel(bridgesSection.sectionName, sectionListBy)
+                                sectionLabel(bridgesSection.sectionName, brigeInfoGrouping)
                                     .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
                                     .font(.title3)
                                     .padding([.leading])
                                 Spacer()
                             }
                         }
-                 //       .padding([.top], 5)
                         .font(.headline)
                         .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
                         .background(bridgesSection.pbColorPalate.textBgnd)
                     }
-           //         .padding([.bottom], 20)
-                    
-                }
-                //       .listStyle(.grouped)
+                    }
             }
+        }
             .background(Color.black)
             .navigationBarHidden(true)
         }
-        //     .foregroundColor(Color.blue)
         .navigationViewStyle(StackNavigationViewStyle())
     }
     
     @ViewBuilder
-    private func sectionLabel(_ sectionName: String, _ sectionListby: BridgeListViewModel.SectionListBy) -> some View {
+    private func sectionLabel(_ sectionName: String, _ sectionListby: BridgeListViewModel.BridgeInfoGrouping) -> some View {
         
         switch sectionListby {
         case .neighborhood:
@@ -75,6 +72,51 @@ struct BridgeListView: View {
             Text("Built in \(sectionName)")
         }
     }
+    
+    private func menuBar() -> some View {
+        HStack {
+            Spacer()
+            Text("Pittsburgh Bridges")
+                .foregroundColor(.pbTitleTextFgnd)
+                .font(.title)
+            Spacer()
+            sortMenu()
+                .padding(.trailing, 10)
+        }
+        .background(Color.pbTitleTextBgnd)
+    }
+    
+    private func sortMenu() -> some View {
+        Menu(content: {
+            Button {
+                brigeInfoGrouping = .name
+            } label: {
+                makeCheckedSortLabel("By Names", selectedSection: .name)
+            }
+            Button {
+                brigeInfoGrouping = .neighborhood
+            } label: {
+                makeCheckedSortLabel("By Neighborhoods", selectedSection: .neighborhood)
+            }
+            Button {
+                brigeInfoGrouping = .year
+            } label: {
+                makeCheckedSortLabel("By Year Built", selectedSection: .year)
+            }
+        }, label: {
+            Label("Sort", systemImage: "rectangle.split.3x3")
+                .labelStyle(.iconOnly)
+        })
+    }
+    
+    private func makeCheckedSortLabel(_ name: String, selectedSection: BridgeListViewModel.BridgeInfoGrouping) -> Label<Text, Image> {
+        if self.brigeInfoGrouping == selectedSection {
+            return Label(name, systemImage: "checkmark.square.fill")
+        } else {
+            return Label(name, systemImage: "square")
+        }
+    }
+    
 }
 
 struct BridgeListView_Previews: PreviewProvider {

--- a/PittsburghCityBridges/Views/BridgeMapView.swift
+++ b/PittsburghCityBridges/Views/BridgeMapView.swift
@@ -10,9 +10,9 @@ import SwiftUI
 struct BridgeMapView: View {
     @EnvironmentObject var bridgeStore: BridgeStore
     var body: some View {
-        VStack {
-            Text("City Bridges Map")
-                .font(.title2) 
+        VStack(spacing: 0){
+            TitleHeader()
+                .padding([.bottom], 5)
             BridgeMapUIView(region: MapViewModel().multipleBridgesRegion, bridgeModels: bridgeStore.bridgeModels, showsBridgeImage: true)
         }
     }

--- a/PittsburghCityBridges/Views/BridgeMenuBar.swift
+++ b/PittsburghCityBridges/Views/BridgeMenuBar.swift
@@ -1,0 +1,65 @@
+//
+//  BridgeMenuBar.swift
+//  PittsburghCityBridges
+//
+//  Created by MAKinney on 12/30/21.
+//
+
+import SwiftUI
+
+struct BridgeMenuBar: View {
+    
+    @Binding var bridgeInfoGrouping: BridgeListViewModel.BridgeInfoGrouping
+    var pbColorPalate = PBColorPalate()
+    
+    var body: some View {
+        HStack {
+            Spacer()
+            Text("Pittsburgh Bridges")
+                .foregroundColor(pbColorPalate.titleTextFgnd)
+                .font(.title)
+            Spacer()
+            sortMenu()
+                .padding(.trailing, 10)
+        }
+        .background(pbColorPalate.titleTextBgnd)
+    }
+    
+    private func sortMenu() -> some View {
+        Menu(content: {
+            Button {
+                bridgeInfoGrouping = .name
+            } label: {
+                makeCheckedSortLabel("By Names", selectedSection: .name)
+            }
+            Button {
+                bridgeInfoGrouping = .neighborhood
+            } label: {
+                makeCheckedSortLabel("By Neighborhoods", selectedSection: .neighborhood)
+            }
+            Button {
+                bridgeInfoGrouping = .year
+            } label: {
+                makeCheckedSortLabel("By Year Built", selectedSection: .year)
+            }
+        }, label: {
+            Label("Sort", systemImage: "arrow.up.arrow.down.square")
+                .labelStyle(.titleAndIcon)
+        })
+    }
+    
+    private func makeCheckedSortLabel(_ name: String, selectedSection: BridgeListViewModel.BridgeInfoGrouping) -> Label<Text, Image> {
+        if self.bridgeInfoGrouping == selectedSection {
+            return Label(name, systemImage: "checkmark.square.fill")
+        } else {
+            return Label(name, systemImage: "square")
+        }
+    }
+    
+}
+
+struct BridgeMenuBar_Previews: PreviewProvider {
+    static var previews: some View {
+        BridgeMenuBar(bridgeInfoGrouping: .constant(.neighborhood), pbColorPalate: PBColorPalate())
+    }
+}

--- a/PittsburghCityBridges/Views/BridgeMenuBar.swift
+++ b/PittsburghCityBridges/Views/BridgeMenuBar.swift
@@ -14,13 +14,13 @@ struct BridgeMenuBar: View {
     
     var body: some View {
         HStack {
-            Spacer()
             Text("Pittsburgh Bridges")
                 .foregroundColor(pbColorPalate.titleTextFgnd)
                 .font(.title)
+                .padding([.leading])
             Spacer()
             sortMenu()
-                .padding(.trailing, 10)
+                .padding([.trailing])
         }
         .background(pbColorPalate.titleTextBgnd)
     }
@@ -44,7 +44,8 @@ struct BridgeMenuBar: View {
             }
         }, label: {
             Label("Sort", systemImage: "arrow.up.arrow.down.square")
-                .labelStyle(.titleAndIcon)
+                .labelStyle(.titleOnly)
+                .font(.title2)
         })
     }
     

--- a/PittsburghCityBridges/Views/BridgePhotosView.swift
+++ b/PittsburghCityBridges/Views/BridgePhotosView.swift
@@ -11,49 +11,120 @@ import os
 struct BridgePhotosView: View {
     @EnvironmentObject var bridgeStore: BridgeStore
     let logger =  Logger(subsystem: AppLogging.subsystem, category: "BridgePhotosView")
-    private var brigeInfoGrouping: BridgeListViewModel.BridgeInfoGrouping = .neighborhood
+    @AppStorage("bridgePhotosView.bridgeInfoGrouping") private var bridgeInfoGrouping = BridgeListViewModel.BridgeInfoGrouping.neighborhood
     private var bridgeListViewModel: BridgeListViewModel
-
-    init(_ bridgeListViewModel: BridgeListViewModel, brigeInfoGrouping: BridgeListViewModel.BridgeInfoGrouping) {
+    
+    init(_ bridgeListViewModel: BridgeListViewModel, bridgeInfoGrouping: BridgeListViewModel.BridgeInfoGrouping) {
         self.bridgeListViewModel = bridgeListViewModel
-        self.brigeInfoGrouping = brigeInfoGrouping
-      }
+        self.bridgeInfoGrouping = bridgeInfoGrouping
+    }
+    
+    init(_ bridgeListViewModel: BridgeListViewModel) {
+        self.bridgeListViewModel = bridgeListViewModel
+    }
     
     var body: some View {
         NavigationView {
+            VStack {
+                menuBar()
                 ScrollView {
-                    LazyVStack(spacing: 10, pinnedViews: [.sectionHeaders]) {
-                        ForEach(bridgeListViewModel.sections(groupedBy: brigeInfoGrouping)) { bridgesSection in
+                    LazyVStack(spacing: 2, pinnedViews: [.sectionHeaders]) {
+                        ForEach(bridgeListViewModel.sections(groupedBy: bridgeInfoGrouping)) { bridgesSection in
                             Section {
                                 ForEach(bridgesSection.bridgeModels) { bridgeModel in
                                     if let imageURL = bridgeModel.imageURL {
                                         NavigationLink(destination: BridgeDetailsView(bridgeModel: bridgeModel, pbColorPalate: bridgesSection.pbColorPalate)) {
-                                            SinglePhotoView(imageURL: imageURL, bridgeModel: bridgeModel)
+                                            SinglePhotoView(imageURL: imageURL, bridgeModel: bridgeModel, pbColorPalate: bridgesSection.pbColorPalate)
                                                 .padding()
                                         }
                                     }
                                 }
-                                //               .background(Color("SteelersBlack"))
                                 .font(.body)
                             } header: {
                                 HStack {
-                                    Spacer()
-                                    Text("\(bridgesSection.sectionName)")
-                                        .foregroundColor(Color("SteelersGold"))
-
+                                    sectionLabel(bridgesSection.sectionName, bridgeInfoGrouping)
+                                        .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
+                                        .font(.title3)
+                                        .padding([.leading])
                                     Spacer()
                                 }
-                                .background(Color("SteelersBlack"))
-                       //         .background(Color.white)
+                                .font(.headline)
+                                .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
+                                .background(bridgesSection.pbColorPalate.textBgnd)
                             }
+                            Divider()
+
+                //            .background(bridgesSection.pbColorPalate.textBgnd)
                         }
                     }
-                    
                 }
-                .padding([.leading, .trailing], 10)
-                .navigationBarHidden(true)
+            }
+            .padding([.leading, .trailing], 10)
+            .navigationBarHidden(true)
         }
         .navigationViewStyle(StackNavigationViewStyle())
+    }
+    
+    @ViewBuilder
+    private func sectionLabel(_ sectionName: String, _ sectionListby: BridgeListViewModel.BridgeInfoGrouping) -> some View {
+        
+        switch sectionListby {
+        case .neighborhood:
+            Text("\(sectionName) Neighborhood")
+        case .name:
+            Text("Starting with \(sectionName)")
+        case .year:
+            Text("Built in \(sectionName)")
+        }
+    }
+    
+    
+}
+
+extension BridgePhotosView {
+    
+    private func menuBar() -> some View {
+        HStack {
+            Spacer()
+            Text("Pittsburgh Bridges")
+                .foregroundColor(.pbTitleTextFgnd)
+                .font(.title)
+            Spacer()
+            sortMenu()
+                .padding(.trailing, 10)
+        }
+        .background(Color.pbTitleTextBgnd)
+    }
+    
+    private func sortMenu() -> some View {
+        Menu(content: {
+            Button {
+                bridgeInfoGrouping = .name
+            } label: {
+                makeCheckedSortLabel("By Names", selectedSection: .name)
+            }
+            Button {
+                bridgeInfoGrouping = .neighborhood
+            } label: {
+                makeCheckedSortLabel("By Neighborhoods", selectedSection: .neighborhood)
+            }
+            Button {
+                bridgeInfoGrouping = .year
+            } label: {
+                makeCheckedSortLabel("By Year Built", selectedSection: .year)
+            }
+        }, label: {
+            Label("Sort", systemImage: "rectangle.split.3x3")
+                .labelStyle(.iconOnly)
+        })
+    }
+    
+    private func makeCheckedSortLabel(_ name: String, selectedSection: BridgeListViewModel.BridgeInfoGrouping) -> Label<Text, Image> {
+        if self.bridgeInfoGrouping == selectedSection {
+            return Label(name, systemImage: "checkmark.square.fill")
+        } else {
+            return Label(name, systemImage: "square")
+        }
     }
 }
 
@@ -62,35 +133,35 @@ struct SinglePhotoView: View {
     @State var imageLoaded = false
     private var bridgeModel: BridgeModel
     private var bridgeImageSystem: BridgeImageSystem
+    private let pbColorPalate: PBColorPalate
     private let imageURL: URL
     
-    init(imageURL: URL, bridgeModel: BridgeModel) {
+    init(imageURL: URL, bridgeModel: BridgeModel, pbColorPalate: PBColorPalate) {
         self.bridgeModel = bridgeModel
+        self.pbColorPalate = pbColorPalate
         self.imageURL = imageURL
         bridgeImageSystem = BridgeImageSystem()
     }
     
     var body: some View {
-        ZStack {
-            Image(uiImage: bridgeImage )
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-            VStack {
-                HStack {
-                    Spacer()
-                    Text("\(bridgeModel.name)")
-                        .font(.caption)
-                        .foregroundColor(Color("SteelersGold"))
-                        .padding([.leading, .trailing], 5)
-                        .background(Color("SteelersBlack"))
-                        .opacity(imageLoaded ? 1.0 : 0.0)
-                    Spacer()
-                }
-                .padding(4)
+        VStack {
+            HStack {
+                Text("\(bridgeModel.name)")
+                    .font(.caption)
+                    .foregroundColor(pbColorPalate.textFgnd)
+                    .padding([.leading, .trailing], 5)
+                    .background(pbColorPalate.textBgnd)
+            
+                    .opacity(imageLoaded ? 1.0 : 0.0)
                 Spacer()
             }
-            BridgeImageLoadingProgressView(bridgeName: bridgeModel.name)
-                .opacity(imageLoaded ? 0.0 : 1.0)
+            ZStack {
+                Image(uiImage: bridgeImage )
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                BridgeImageLoadingProgressView(bridgeName: bridgeModel.name)
+                    .opacity(imageLoaded ? 0.0 : 1.0)
+            }
         }
         .onAppear {
             Task {
@@ -111,7 +182,7 @@ struct SinglePhotoView: View {
 struct BridgePhotosView_Previews: PreviewProvider {
     static let bridgeStore = BridgeStore()
     static var previews: some View {
-        BridgePhotosView(BridgeListViewModel(bridgeStore), brigeInfoGrouping: .name)
+        BridgePhotosView(BridgeListViewModel(bridgeStore), bridgeInfoGrouping: .name)
             .environmentObject(bridgeStore)
             .onAppear {
                 bridgeStore.preview()

--- a/PittsburghCityBridges/Views/BridgePhotosView.swift
+++ b/PittsburghCityBridges/Views/BridgePhotosView.swift
@@ -26,7 +26,7 @@ struct BridgePhotosView: View {
     var body: some View {
         NavigationView {
             VStack {
-                menuBar()
+                BridgeMenuBar(bridgeInfoGrouping: $bridgeInfoGrouping)
                 ScrollView {
                     LazyVStack(spacing: 20, pinnedViews: [.sectionHeaders]) {
                         ForEach(bridgeListViewModel.sections(groupedBy: bridgeInfoGrouping)) { bridgesSection in
@@ -74,54 +74,6 @@ struct BridgePhotosView: View {
             Text("Starting with \(sectionName)")
         case .year:
             Text("Built in \(sectionName)")
-        }
-    }
-    
-    
-}
-
-extension BridgePhotosView {
-    
-    private func menuBar() -> some View {
-        HStack {
-            Spacer()
-            Text("Pittsburgh Bridges")
-                .foregroundColor(.pbTitleTextFgnd)
-                .font(.title)
-            Spacer()
-            sortMenu()
-        }
-        .background(Color.pbTitleTextBgnd)
-    }
-    
-    private func sortMenu() -> some View {
-        Menu(content: {
-            Button {
-                bridgeInfoGrouping = .name
-            } label: {
-                makeCheckedSortLabel("By Names", selectedSection: .name)
-            }
-            Button {
-                bridgeInfoGrouping = .neighborhood
-            } label: {
-                makeCheckedSortLabel("By Neighborhoods", selectedSection: .neighborhood)
-            }
-            Button {
-                bridgeInfoGrouping = .year
-            } label: {
-                makeCheckedSortLabel("By Year Built", selectedSection: .year)
-            }
-        }, label: {
-            Label("Sort", systemImage: "arrow.up.arrow.down.square")
-                .labelStyle(.titleAndIcon)
-        })
-    }
-    
-    private func makeCheckedSortLabel(_ name: String, selectedSection: BridgeListViewModel.BridgeInfoGrouping) -> Label<Text, Image> {
-        if self.bridgeInfoGrouping == selectedSection {
-            return Label(name, systemImage: "checkmark.square.fill")
-        } else {
-            return Label(name, systemImage: "square")
         }
     }
 }

--- a/PittsburghCityBridges/Views/BridgePhotosView.swift
+++ b/PittsburghCityBridges/Views/BridgePhotosView.swift
@@ -28,7 +28,7 @@ struct BridgePhotosView: View {
             VStack {
                 BridgeMenuBar(bridgeInfoGrouping: $bridgeInfoGrouping)
                 ScrollView {
-                    LazyVStack(spacing: 20, pinnedViews: [.sectionHeaders]) {
+                    LazyVStack(spacing: 10, pinnedViews: [.sectionHeaders]) {
                         ForEach(bridgeListViewModel.sections(groupedBy: bridgeInfoGrouping)) { bridgesSection in
                             Section {
                                 ForEach(bridgesSection.bridgeModels) { bridgeModel in
@@ -36,7 +36,7 @@ struct BridgePhotosView: View {
                                         NavigationLink(destination: BridgeDetailsView(bridgeModel: bridgeModel, pbColorPalate: bridgesSection.pbColorPalate)) {
                                             SinglePhotoView(imageURL: imageURL, bridgeModel: bridgeModel, pbColorPalate: bridgesSection.pbColorPalate)
                                         }
-                                        .padding([.top], 5)
+                //                        .padding([.top], 5)
                                     }
                                 }
                                 .font(.body)
@@ -45,7 +45,7 @@ struct BridgePhotosView: View {
                                     sectionLabel(bridgesSection.sectionName, bridgeInfoGrouping)
                                         .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
                                         .font(.title2)
-                               //         .padding([.leading])
+                                        .padding([.leading])
                                     Spacer()
                                 }
                                 .font(.headline)
@@ -58,7 +58,7 @@ struct BridgePhotosView: View {
         //            .padding([.leading,.trailing], 20)
                 }
             }
-            .padding([.leading, .trailing], 20)
+  //          .padding([.leading, .trailing], 20)
             .navigationBarHidden(true)
         }
         .navigationViewStyle(StackNavigationViewStyle())
@@ -100,7 +100,7 @@ struct SinglePhotoView: View {
                 Text("\(bridgeModel.name)")
                     .font(.title3)
                     .foregroundColor(pbColorPalate.textFgnd)
-                    .padding([.leading, .trailing], 5)
+                    .padding([.leading])
                     .background(pbColorPalate.textBgnd)
                     .opacity(imageLoaded ? 1.0 : 0.0)
                 Spacer()

--- a/PittsburghCityBridges/Views/BridgePhotosView.swift
+++ b/PittsburghCityBridges/Views/BridgePhotosView.swift
@@ -11,20 +11,19 @@ import os
 struct BridgePhotosView: View {
     @EnvironmentObject var bridgeStore: BridgeStore
     let logger =  Logger(subsystem: AppLogging.subsystem, category: "BridgePhotosView")
-    private var sectionListBy: BridgeListViewModel.SectionListBy = .neighborhood
+    private var brigeInfoGrouping: BridgeListViewModel.BridgeInfoGrouping = .neighborhood
     private var bridgeListViewModel: BridgeListViewModel
 
-    init(_ bridgeListViewModel: BridgeListViewModel, sectionListBy: BridgeListViewModel.SectionListBy = .name) {
+    init(_ bridgeListViewModel: BridgeListViewModel, brigeInfoGrouping: BridgeListViewModel.BridgeInfoGrouping) {
         self.bridgeListViewModel = bridgeListViewModel
-        self.sectionListBy = sectionListBy
-        //      UITableView.appearance().backgroundColor = .green
-    }
+        self.brigeInfoGrouping = brigeInfoGrouping
+      }
     
     var body: some View {
         NavigationView {
                 ScrollView {
                     LazyVStack(spacing: 10, pinnedViews: [.sectionHeaders]) {
-                        ForEach(bridgeListViewModel.sectionList(sectionListBy)) { bridgesSection in
+                        ForEach(bridgeListViewModel.sections(groupedBy: brigeInfoGrouping)) { bridgesSection in
                             Section {
                                 ForEach(bridgesSection.bridgeModels) { bridgeModel in
                                     if let imageURL = bridgeModel.imageURL {
@@ -112,7 +111,7 @@ struct SinglePhotoView: View {
 struct BridgePhotosView_Previews: PreviewProvider {
     static let bridgeStore = BridgeStore()
     static var previews: some View {
-        BridgePhotosView(BridgeListViewModel(bridgeStore))
+        BridgePhotosView(BridgeListViewModel(bridgeStore), brigeInfoGrouping: .name)
             .environmentObject(bridgeStore)
             .onAppear {
                 bridgeStore.preview()

--- a/PittsburghCityBridges/Views/BridgePhotosView.swift
+++ b/PittsburghCityBridges/Views/BridgePhotosView.swift
@@ -13,7 +13,7 @@ struct BridgePhotosView: View {
     let logger =  Logger(subsystem: AppLogging.subsystem, category: "BridgePhotosView")
     @AppStorage("bridgePhotosView.bridgeInfoGrouping") private var bridgeInfoGrouping = BridgeListViewModel.BridgeInfoGrouping.neighborhood
     private var bridgeListViewModel: BridgeListViewModel
-    
+
     init(_ bridgeListViewModel: BridgeListViewModel, bridgeInfoGrouping: BridgeListViewModel.BridgeInfoGrouping) {
         self.bridgeListViewModel = bridgeListViewModel
         self.bridgeInfoGrouping = bridgeInfoGrouping
@@ -28,15 +28,15 @@ struct BridgePhotosView: View {
             VStack {
                 menuBar()
                 ScrollView {
-                    LazyVStack(spacing: 2, pinnedViews: [.sectionHeaders]) {
+                    LazyVStack(spacing: 20, pinnedViews: [.sectionHeaders]) {
                         ForEach(bridgeListViewModel.sections(groupedBy: bridgeInfoGrouping)) { bridgesSection in
                             Section {
                                 ForEach(bridgesSection.bridgeModels) { bridgeModel in
                                     if let imageURL = bridgeModel.imageURL {
                                         NavigationLink(destination: BridgeDetailsView(bridgeModel: bridgeModel, pbColorPalate: bridgesSection.pbColorPalate)) {
                                             SinglePhotoView(imageURL: imageURL, bridgeModel: bridgeModel, pbColorPalate: bridgesSection.pbColorPalate)
-                                                .padding()
                                         }
+                                        .padding([.top], 5)
                                     }
                                 }
                                 .font(.body)
@@ -44,22 +44,21 @@ struct BridgePhotosView: View {
                                 HStack {
                                     sectionLabel(bridgesSection.sectionName, bridgeInfoGrouping)
                                         .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
-                                        .font(.title3)
-                                        .padding([.leading])
+                                        .font(.title2)
+                               //         .padding([.leading])
                                     Spacer()
                                 }
                                 .font(.headline)
                                 .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
                                 .background(bridgesSection.pbColorPalate.textBgnd)
                             }
-                            Divider()
-
                 //            .background(bridgesSection.pbColorPalate.textBgnd)
                         }
                     }
+        //            .padding([.leading,.trailing], 20)
                 }
             }
-            .padding([.leading, .trailing], 10)
+            .padding([.leading, .trailing], 20)
             .navigationBarHidden(true)
         }
         .navigationViewStyle(StackNavigationViewStyle())
@@ -91,7 +90,6 @@ extension BridgePhotosView {
                 .font(.title)
             Spacer()
             sortMenu()
-                .padding(.trailing, 10)
         }
         .background(Color.pbTitleTextBgnd)
     }
@@ -114,8 +112,8 @@ extension BridgePhotosView {
                 makeCheckedSortLabel("By Year Built", selectedSection: .year)
             }
         }, label: {
-            Label("Sort", systemImage: "rectangle.split.3x3")
-                .labelStyle(.iconOnly)
+            Label("Sort", systemImage: "arrow.up.arrow.down.square")
+                .labelStyle(.titleAndIcon)
         })
     }
     
@@ -134,6 +132,7 @@ struct SinglePhotoView: View {
     private var bridgeModel: BridgeModel
     private var bridgeImageSystem: BridgeImageSystem
     private let pbColorPalate: PBColorPalate
+    private let imageCornerRadius: CGFloat = 10
     private let imageURL: URL
     
     init(imageURL: URL, bridgeModel: BridgeModel, pbColorPalate: PBColorPalate) {
@@ -147,11 +146,10 @@ struct SinglePhotoView: View {
         VStack {
             HStack {
                 Text("\(bridgeModel.name)")
-                    .font(.caption)
+                    .font(.title3)
                     .foregroundColor(pbColorPalate.textFgnd)
                     .padding([.leading, .trailing], 5)
                     .background(pbColorPalate.textBgnd)
-            
                     .opacity(imageLoaded ? 1.0 : 0.0)
                 Spacer()
             }
@@ -159,10 +157,16 @@ struct SinglePhotoView: View {
                 Image(uiImage: bridgeImage )
                     .resizable()
                     .aspectRatio(contentMode: .fit)
+                    .cornerRadius(imageCornerRadius)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: imageCornerRadius)
+                            .stroke(Color.secondary, lineWidth: 2)
+                    )
                 BridgeImageLoadingProgressView(bridgeName: bridgeModel.name)
                     .opacity(imageLoaded ? 0.0 : 1.0)
             }
         }
+        .background(pbColorPalate.textBgnd)
         .onAppear {
             Task {
                 do {

--- a/PittsburghCityBridges/Views/BridgePhotosView.swift
+++ b/PittsburghCityBridges/Views/BridgePhotosView.swift
@@ -28,7 +28,7 @@ struct BridgePhotosView: View {
             VStack {
                 BridgeMenuBar(bridgeInfoGrouping: $bridgeInfoGrouping)
                 ScrollView {
-                    LazyVStack(spacing: 10, pinnedViews: [.sectionHeaders]) {
+                    LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
                         ForEach(bridgeListViewModel.sections(groupedBy: bridgeInfoGrouping)) { bridgesSection in
                             Section {
                                 ForEach(bridgesSection.bridgeModels) { bridgeModel in
@@ -36,7 +36,6 @@ struct BridgePhotosView: View {
                                         NavigationLink(destination: BridgeDetailsView(bridgeModel: bridgeModel, pbColorPalate: bridgesSection.pbColorPalate)) {
                                             SinglePhotoView(imageURL: imageURL, bridgeModel: bridgeModel, pbColorPalate: bridgesSection.pbColorPalate)
                                         }
-                //                        .padding([.top], 5)
                                     }
                                 }
                                 .font(.body)
@@ -45,20 +44,17 @@ struct BridgePhotosView: View {
                                     sectionLabel(bridgesSection.sectionName, bridgeInfoGrouping)
                                         .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
                                         .font(.title2)
-                                        .padding([.leading])
+                                        .padding([.leading, .top, .bottom])
                                     Spacer()
                                 }
                                 .font(.headline)
                                 .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
                                 .background(bridgesSection.pbColorPalate.textBgnd)
                             }
-                //            .background(bridgesSection.pbColorPalate.textBgnd)
                         }
                     }
-        //            .padding([.leading,.trailing], 20)
                 }
             }
-  //          .padding([.leading, .trailing], 20)
             .navigationBarHidden(true)
         }
         .navigationViewStyle(StackNavigationViewStyle())
@@ -71,7 +67,7 @@ struct BridgePhotosView: View {
         case .neighborhood:
             Text("\(sectionName) Neighborhood")
         case .name:
-            Text("Starting with \(sectionName)")
+            Text("\(sectionName)")
         case .year:
             Text("Built in \(sectionName)")
         }
@@ -95,28 +91,29 @@ struct SinglePhotoView: View {
     }
     
     var body: some View {
-        VStack {
-            HStack {
-                Text("\(bridgeModel.name)")
-                    .font(.title3)
-                    .foregroundColor(pbColorPalate.textFgnd)
-                    .padding([.leading])
-                    .background(pbColorPalate.textBgnd)
-                    .opacity(imageLoaded ? 1.0 : 0.0)
-                Spacer()
+        ZStack {
+            VStack {
+                HStack {
+                    Text("\(bridgeModel.name)")
+                        .font(.title3)
+                        .foregroundColor(pbColorPalate.textFgnd)
+                        .opacity(imageLoaded ? 1.0 : 0.0)
+                    Spacer()
+                }
+                ZStack {
+                    Image(uiImage: bridgeImage )
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .cornerRadius(imageCornerRadius)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: imageCornerRadius)
+                                .stroke(Color.secondary, lineWidth: 2)
+                        )
+                    BridgeImageLoadingProgressView(bridgeName: bridgeModel.name)
+                        .opacity(imageLoaded ? 0.0 : 1.0)
+                }
             }
-            ZStack {
-                Image(uiImage: bridgeImage )
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .cornerRadius(imageCornerRadius)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: imageCornerRadius)
-                            .stroke(Color.secondary, lineWidth: 2)
-                    )
-                BridgeImageLoadingProgressView(bridgeName: bridgeModel.name)
-                    .opacity(imageLoaded ? 0.0 : 1.0)
-            }
+            .padding([.leading, .trailing, .bottom])
         }
         .background(pbColorPalate.textBgnd)
         .onAppear {

--- a/PittsburghCityBridges/Views/BridgePhotosView.swift
+++ b/PittsburghCityBridges/Views/BridgePhotosView.swift
@@ -25,8 +25,9 @@ struct BridgePhotosView: View {
     
     var body: some View {
         NavigationView {
-            VStack {
-                BridgeMenuBar(bridgeInfoGrouping: $bridgeInfoGrouping)
+            VStack(spacing: 0) {
+                TitleHeader()
+                HeaderToolBar(bridgeInfoGrouping: $bridgeInfoGrouping)
                 ScrollView {
                     LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
                         ForEach(bridgeListViewModel.sections(groupedBy: bridgeInfoGrouping)) { bridgesSection in
@@ -44,7 +45,9 @@ struct BridgePhotosView: View {
                                     sectionLabel(bridgesSection.sectionName, bridgeInfoGrouping)
                                         .foregroundColor(bridgesSection.pbColorPalate.textFgnd)
                                         .font(.title2)
-                                        .padding([.leading, .top, .bottom])
+                                        .padding([.leading])
+                                        .padding([.top], 10)
+                                        .padding([.bottom], 5)
                                     Spacer()
                                 }
                                 .font(.headline)
@@ -65,11 +68,11 @@ struct BridgePhotosView: View {
         
         switch sectionListby {
         case .neighborhood:
-            Text("\(sectionName) Neighborhood")
+            Text("\(sectionName)")
         case .name:
             Text("\(sectionName)")
         case .year:
-            Text("Built in \(sectionName)")
+            Text("\(sectionName)")
         }
     }
 }

--- a/PittsburghCityBridges/Views/BridgeViewsView.swift
+++ b/PittsburghCityBridges/Views/BridgeViewsView.swift
@@ -14,7 +14,7 @@ enum ViewBridgeAs: Int {
 struct BridgeViewsView: View {
     private var bridgeListViewModel: BridgeListViewModel
     @AppStorage("viewBridgeAs") private var viewBridgeAs = ViewBridgeAs.list
-    @AppStorage("brigeInfoGrouping") private var brigeInfoGrouping = BridgeListViewModel.BridgeInfoGrouping.neighborhood
+    @AppStorage("bridgeInfoGrouping") private var bridgeInfoGrouping = BridgeListViewModel.BridgeInfoGrouping.neighborhood
     
     init(_ bridgeListViewModel: BridgeListViewModel) {
         self.bridgeListViewModel = bridgeListViewModel
@@ -26,12 +26,12 @@ struct BridgeViewsView: View {
             case .list:
                 VStack {
                     menuBar()
-                    BridgeListView(bridgeListViewModel, brigeInfoGrouping: brigeInfoGrouping)
+                    BridgeListView(bridgeListViewModel, bridgeInfoGrouping: bridgeInfoGrouping)
                 }
             case .photos:
                 VStack {
                     menuBar()
-                    BridgePhotosView(bridgeListViewModel, brigeInfoGrouping: brigeInfoGrouping)
+                    BridgePhotosView(bridgeListViewModel, bridgeInfoGrouping: bridgeInfoGrouping)
                 }
             }
         }
@@ -57,7 +57,7 @@ struct BridgeViewsView: View {
     private func sortedAs() -> some View {
         HStack {
             Spacer()
-            switch brigeInfoGrouping {
+            switch bridgeInfoGrouping {
             case .neighborhood:
                 Text("by Neighborhood")
                     .font(.headline)
@@ -89,17 +89,17 @@ struct BridgeViewsView: View {
     private func sortMenu() -> some View {
         Menu(content: {
             Button {
-                brigeInfoGrouping = .name
+                bridgeInfoGrouping = .name
             } label: {
                 makeCheckedSortLabel("By Names", selectedSection: .name)
             }
             Button {
-                brigeInfoGrouping = .neighborhood
+                bridgeInfoGrouping = .neighborhood
             } label: {
                 makeCheckedSortLabel("By Neighborhoods", selectedSection: .neighborhood)
             }
             Button {
-                brigeInfoGrouping = .year
+                bridgeInfoGrouping = .year
             } label: {
                 makeCheckedSortLabel("By Year Built", selectedSection: .year)
             }
@@ -110,7 +110,7 @@ struct BridgeViewsView: View {
     }
     
     private func makeCheckedSortLabel(_ name: String, selectedSection: BridgeListViewModel.BridgeInfoGrouping) -> Label<Text, Image> {
-        if self.brigeInfoGrouping == selectedSection {
+        if self.bridgeInfoGrouping == selectedSection {
             return Label(name, systemImage: "checkmark.square.fill")
         } else {
             return Label(name, systemImage: "square")

--- a/PittsburghCityBridges/Views/BridgeViewsView.swift
+++ b/PittsburghCityBridges/Views/BridgeViewsView.swift
@@ -14,11 +14,10 @@ enum ViewBridgeAs: Int {
 struct BridgeViewsView: View {
     private var bridgeListViewModel: BridgeListViewModel
     @AppStorage("viewBridgeAs") private var viewBridgeAs = ViewBridgeAs.list
-    @AppStorage("sectionListBy") private var sectionListBy = BridgeListViewModel.SectionListBy.neighborhood
+    @AppStorage("brigeInfoGrouping") private var brigeInfoGrouping = BridgeListViewModel.BridgeInfoGrouping.neighborhood
     
     init(_ bridgeListViewModel: BridgeListViewModel) {
         self.bridgeListViewModel = bridgeListViewModel
-        //      UITableView.appearance().backgroundColor = .green
     }
     
     var body: some View {
@@ -27,14 +26,12 @@ struct BridgeViewsView: View {
             case .list:
                 VStack {
                     menuBar()
-        //            sortedAs()
-                    BridgeListView(bridgeListViewModel, sectionListBy: sectionListBy)
+                    BridgeListView(bridgeListViewModel, brigeInfoGrouping: brigeInfoGrouping)
                 }
             case .photos:
                 VStack {
                     menuBar()
-           //         sortedAs()
-                    BridgePhotosView(bridgeListViewModel, sectionListBy: sectionListBy)
+                    BridgePhotosView(bridgeListViewModel, brigeInfoGrouping: brigeInfoGrouping)
                 }
             }
         }
@@ -60,7 +57,7 @@ struct BridgeViewsView: View {
     private func sortedAs() -> some View {
         HStack {
             Spacer()
-            switch sectionListBy {
+            switch brigeInfoGrouping {
             case .neighborhood:
                 Text("by Neighborhood")
                     .font(.headline)
@@ -92,17 +89,17 @@ struct BridgeViewsView: View {
     private func sortMenu() -> some View {
         Menu(content: {
             Button {
-                sectionListBy = .name
+                brigeInfoGrouping = .name
             } label: {
                 makeCheckedSortLabel("By Names", selectedSection: .name)
             }
             Button {
-                sectionListBy = .neighborhood
+                brigeInfoGrouping = .neighborhood
             } label: {
                 makeCheckedSortLabel("By Neighborhoods", selectedSection: .neighborhood)
             }
             Button {
-                sectionListBy = .year
+                brigeInfoGrouping = .year
             } label: {
                 makeCheckedSortLabel("By Year Built", selectedSection: .year)
             }
@@ -112,8 +109,8 @@ struct BridgeViewsView: View {
         })
     }
     
-    private func makeCheckedSortLabel(_ name: String, selectedSection: BridgeListViewModel.SectionListBy) -> Label<Text, Image> {
-        if self.sectionListBy == selectedSection {
+    private func makeCheckedSortLabel(_ name: String, selectedSection: BridgeListViewModel.BridgeInfoGrouping) -> Label<Text, Image> {
+        if self.brigeInfoGrouping == selectedSection {
             return Label(name, systemImage: "checkmark.square.fill")
         } else {
             return Label(name, systemImage: "square")

--- a/PittsburghCityBridges/Views/ContentView.swift
+++ b/PittsburghCityBridges/Views/ContentView.swift
@@ -12,14 +12,18 @@ struct ContentView: View {
 
     var body: some View {
         TabView {
+            BridgePhotosView(BridgeListViewModel(bridgeStore))
+                .tabItem {
+                    Label("Photos", systemImage: "photo.on.rectangle")
+                }
             BridgeListView(BridgeListViewModel(bridgeStore))
                 .tabItem {
-                    Label("List", systemImage: "list.dash")
+                    Label("Lists", systemImage: "list.dash")
                 }
-            BridgeViewsView(BridgeListViewModel(bridgeStore))
-                .tabItem {
-                    Label("Bridges", systemImage: "waveform")
-                }
+//            BridgeViewsView(BridgeListViewModel(bridgeStore))
+//                .tabItem {
+//                    Label("Bridges", systemImage: "waveform")
+//                }
 //            BridgePhotosView(BridgeListViewModel(bridgeStore))
 //                .tabItem {
 //                    Label("Photos", systemImage: "photo")

--- a/PittsburghCityBridges/Views/ContentView.swift
+++ b/PittsburghCityBridges/Views/ContentView.swift
@@ -19,21 +19,21 @@ struct ContentView: View {
         TabView {
             BridgeListView(BridgeListViewModel(bridgeStore))
                 .tabItem {
-                    Label("Lists", systemImage: "list.dash")
+                    Label("Bridge List", systemImage: "list.dash")
                 }
             BridgePhotosView(BridgeListViewModel(bridgeStore))
                 .tabItem {
-                    Label("Photos", systemImage: "photo.on.rectangle")
+                    Label("Bridge Photos", systemImage: "photo.on.rectangle")
                 }
             BridgeMapView()
                 .tabItem {
-                    Label("Map", systemImage: "map")
+                    Label("Bridge Map", systemImage: "map")
                 }
         }
         .onAppear {
             bridgeStore.refreshBridgeModels()
         }
-//        .accentColor(.orange)
+//        .accentColor(Color.pbAccent)
     }
 }
 

--- a/PittsburghCityBridges/Views/ContentView.swift
+++ b/PittsburghCityBridges/Views/ContentView.swift
@@ -12,6 +12,10 @@ struct ContentView: View {
 
     var body: some View {
         TabView {
+            BridgeListView(BridgeListViewModel(bridgeStore))
+                .tabItem {
+                    Label("List", systemImage: "list.dash")
+                }
             BridgeViewsView(BridgeListViewModel(bridgeStore))
                 .tabItem {
                     Label("Bridges", systemImage: "waveform")

--- a/PittsburghCityBridges/Views/ContentView.swift
+++ b/PittsburghCityBridges/Views/ContentView.swift
@@ -33,7 +33,7 @@ struct ContentView: View {
         .onAppear {
             bridgeStore.refreshBridgeModels()
         }
-        .accentColor(.orange)
+//        .accentColor(.orange)
     }
 }
 

--- a/PittsburghCityBridges/Views/ContentView.swift
+++ b/PittsburghCityBridges/Views/ContentView.swift
@@ -9,25 +9,22 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject var bridgeStore: BridgeStore
+    
+    init() {
+ //       UITabBar.appearance().isTranslucent = false
+ //       UITabBar.appearance().backgroundColor = UIColor.systemBackground
+    }
 
     var body: some View {
         TabView {
-            BridgePhotosView(BridgeListViewModel(bridgeStore))
-                .tabItem {
-                    Label("Photos", systemImage: "photo.on.rectangle")
-                }
             BridgeListView(BridgeListViewModel(bridgeStore))
                 .tabItem {
                     Label("Lists", systemImage: "list.dash")
                 }
-//            BridgeViewsView(BridgeListViewModel(bridgeStore))
-//                .tabItem {
-//                    Label("Bridges", systemImage: "waveform")
-//                }
-//            BridgePhotosView(BridgeListViewModel(bridgeStore))
-//                .tabItem {
-//                    Label("Photos", systemImage: "photo")
-//                }
+            BridgePhotosView(BridgeListViewModel(bridgeStore))
+                .tabItem {
+                    Label("Photos", systemImage: "photo.on.rectangle")
+                }
             BridgeMapView()
                 .tabItem {
                     Label("Map", systemImage: "map")
@@ -36,8 +33,7 @@ struct ContentView: View {
         .onAppear {
             bridgeStore.refreshBridgeModels()
         }
-        .accentColor(.blue)
-   //     .colorScheme(ColorScheme.dark)
+        .accentColor(.orange)
     }
 }
 
@@ -47,3 +43,4 @@ struct MainView_Previews: PreviewProvider {
             .environmentObject(BridgeStore())
     }
 }
+    

--- a/PittsburghCityBridges/Views/HeaderToolBar.swift
+++ b/PittsburghCityBridges/Views/HeaderToolBar.swift
@@ -7,20 +7,17 @@
 
 import SwiftUI
 
-struct BridgeMenuBar: View {
+struct HeaderToolBar: View {
     
     @Binding var bridgeInfoGrouping: BridgeListViewModel.BridgeInfoGrouping
     var pbColorPalate = PBColorPalate()
-    
+
     var body: some View {
         HStack {
-            Text("Pittsburgh Bridges")
-                .foregroundColor(pbColorPalate.titleTextFgnd)
-                .font(.title)
-                .padding([.leading])
-            Spacer()
             sortMenu()
-                .padding([.trailing])
+                .padding([.leading])
+                .padding([.vertical], 5)
+            Spacer()
         }
         .background(pbColorPalate.titleTextBgnd)
     }
@@ -43,8 +40,8 @@ struct BridgeMenuBar: View {
                 makeCheckedSortLabel("By Year Built", selectedSection: .year)
             }
         }, label: {
-            Label("Sort", systemImage: "arrow.up.arrow.down.square")
-                .labelStyle(.titleOnly)
+            Label("Sort", systemImage: "slider.vertical.3")
+                .labelStyle(.iconOnly)
                 .font(.title2)
         })
     }
@@ -61,6 +58,6 @@ struct BridgeMenuBar: View {
 
 struct BridgeMenuBar_Previews: PreviewProvider {
     static var previews: some View {
-        BridgeMenuBar(bridgeInfoGrouping: .constant(.neighborhood), pbColorPalate: PBColorPalate())
+        HeaderToolBar(bridgeInfoGrouping: .constant(.neighborhood))
     }
 }

--- a/PittsburghCityBridges/Views/TitleHeader.swift
+++ b/PittsburghCityBridges/Views/TitleHeader.swift
@@ -1,0 +1,29 @@
+//
+//  TitleHeaderView.swift
+//  PittsburghCityBridges
+//
+//  Created by MAKinney on 12/31/21.
+//
+
+import SwiftUI
+
+struct TitleHeader: View {
+    var pbColorPalate = PBColorPalate()
+    var body: some View {
+        HStack {
+            Spacer()
+            Text("Pittsburgh City Bridges")
+                .foregroundColor(pbColorPalate.titleTextFgnd)
+                .font(.title2)
+                .italic()
+            Spacer()
+        }
+        .background(pbColorPalate.titleTextBgnd)
+    }
+}
+
+struct TitleHeaderView_Previews: PreviewProvider {
+    static var previews: some View {
+        TitleHeader()
+    }
+}


### PR DESCRIPTION
Major refactor for tabview and list and photo views.  
Dedicated tab again for each.  
removed List / Photos button in top left and replaced with decided views, again, for bridge list and bridge photos screens. 
Factored out menu code and sort code from the list and photos view and put them in their own views for header and toolbar. 
Layout updates for padding and fonts to all screens. Now has "Pittsburgh City Bridges' as header title in all views. 
Updated some colors and usages. 
more
