### PR TITLE
Tab view tranparency fix

### DIFF
--- a/PittsburghCityBridges/Appearance/AppColors.swift
+++ b/PittsburghCityBridges/Appearance/AppColors.swift
@@ -19,8 +19,12 @@ extension Color {
     static let pbTextFgndConcrete = Color(light: Asset.bridgeBlackA, dark: Asset.bridgeConcreteA)
     static let pbTextBgndConcrete = Color(light: Asset.bridgeConcreteA, dark: Asset.bridgeBlackA)
     static let pbTitleTextFgnd =  Color(light: UIColor.label , dark: Asset.bridgeYellowA)
-    static let pbTitleTextBgnd =  Color(light: UIColor.tertiarySystemBackground , dark: Asset.bridgeBlackA)
+    static let pbTitleTextBgnd =  Color(light: UIColor.secondarySystemBackground , dark: Asset.bridgeBlackA)
     static let steelerBlack = Color(uiColor: Asset.bridgeBlackA)
+}
+
+extension UIColor {
+    static let pbTabBarBackground = UIColor(light: UIColor.secondarySystemBackground, dark: Asset.bridgeBlackA)
 }
 
 private struct Asset {

--- a/PittsburghCityBridges/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/PittsburghCityBridges/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -2,31 +2,8 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0.219",
-          "green" : "0.413",
-          "red" : "0.000"
-        }
-      },
-      "idiom" : "universal"
-    },
-    {
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0.000",
-          "green" : "0.560",
-          "red" : "0.000"
-        }
+        "platform" : "universal",
+        "reference" : "systemBlueColor"
       },
       "idiom" : "universal"
     }

--- a/PittsburghCityBridges/Views/BridgeDetailsView.swift
+++ b/PittsburghCityBridges/Views/BridgeDetailsView.swift
@@ -113,6 +113,12 @@ struct BridgeDetailsView: View {
                 GeometryReader { geometry in
                     ScrollView(showsIndicators: false) {
                         VStack(alignment: .leading) {
+                            Text("\(bridgeModel.name)")
+                                .font(.headline)
+                                .padding([.leading])
+                            Text(bridgeModel.builtHistory())
+                                .padding([.leading])
+                    
                             HStack {
                                 Spacer()
                                 ZStack {
@@ -142,15 +148,11 @@ struct BridgeDetailsView: View {
                                 Spacer()
                             }
                             //          .matchedGeometryEffect(id: "BridgeView", in: bridgeAnimations)
-                            Text("\(bridgeModel.name)")
-                                .font(.headline)
-                                .padding(.vertical)
-                            Text(bridgeModel.builtHistory())
-                                .padding(.bottom)
                             Text(bridgeModel.neighborhoods())
+                                .padding()
+                          
                             HStack {
                                 Spacer()
-                                
                                 makeMapView(bridgeModel)
                                     .frame(height: 200)
                                     .cornerRadius(imageCornerRadius)
@@ -190,19 +192,20 @@ struct BridgeDetailsView: View {
             VStack {
                 HStack {
                     if let locationCoordinate = bridgeModel.locationCoordinate {
-                        Spacer()
+                       
                         Button {
                             DirectionsProvider.shared.requestDirectionsTo(locationCoordinate)
                         } label: {
                             Label("Directions", systemImage: "arrow.triangle.turn.up.right.circle.fill")
                                 .padding(4)
-                                .background(Color(white: 0.9))
+                                .background(Color.pbTitleTextBgnd)
                         }
                         .overlay(
                             RoundedRectangle(cornerRadius: buttonCornerRadius)
                                 .stroke(Color.secondary, lineWidth: 2)
                         )
                         .padding()
+                        Spacer()
                     }
                 }
                 Spacer()

--- a/PittsburghCityBridges/Views/BridgeListView.swift
+++ b/PittsburghCityBridges/Views/BridgeListView.swift
@@ -25,7 +25,7 @@ struct BridgeListView: View {
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
-                TitleHeader()
+                TitleHeader(title: "Bridges List")
                 HeaderToolBar(bridgeInfoGrouping: $bridgeInfoGrouping)
                 ScrollView {
                     LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {

--- a/PittsburghCityBridges/Views/BridgeListView.swift
+++ b/PittsburghCityBridges/Views/BridgeListView.swift
@@ -25,7 +25,7 @@ struct BridgeListView: View {
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
-                TitleHeader(title: "Bridges List")
+                TitleHeader(title: "Pittsburgh City Bridges")
                 HeaderToolBar(bridgeInfoGrouping: $bridgeInfoGrouping)
                 ScrollView {
                     LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {

--- a/PittsburghCityBridges/Views/BridgeMapUIView.swift
+++ b/PittsburghCityBridges/Views/BridgeMapUIView.swift
@@ -110,7 +110,10 @@ struct BridgeMapUIView: UIViewRepresentable {
             annotationView.markerTintColor = .systemRed
             annotationView.canShowCallout = true
             let buttonImage = UIImage(systemName: "arrow.triangle.turn.up.right.circle.fill") ?? UIImage()
-            let directionsRequestButton = UIButton.systemButton(with: buttonImage, target: nil, action: nil) // so we can tap and get the delegate callback
+            let directionsRequestButton = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 50)) // so we can tap and get the delegate callback
+            directionsRequestButton.setImage(buttonImage, for: .normal)
+       //     directionsRequestButton.setTitle("Directions", for: .normal)
+      //      directionsRequestButton.setTitleColor(UIColor.red, for: .normal)
             annotationView.rightCalloutAccessoryView = directionsRequestButton
             if hasDetailAccessoryView {
                 let bridgeMapDetailAccessoryView = BridgeMapDetailAccessoryView(bridgeModel: bridgeMapAnnotation.bridgeModel)

--- a/PittsburghCityBridges/Views/BridgeMapView.swift
+++ b/PittsburghCityBridges/Views/BridgeMapView.swift
@@ -11,7 +11,7 @@ struct BridgeMapView: View {
     @EnvironmentObject var bridgeStore: BridgeStore
     var body: some View {
         VStack(spacing: 0){
-            TitleHeader()
+            TitleHeader(title: "Bridges Map")
                 .padding([.bottom], 5)
             BridgeMapUIView(region: MapViewModel().multipleBridgesRegion, bridgeModels: bridgeStore.bridgeModels, showsBridgeImage: true)
         }

--- a/PittsburghCityBridges/Views/BridgePhotosView.swift
+++ b/PittsburghCityBridges/Views/BridgePhotosView.swift
@@ -26,7 +26,7 @@ struct BridgePhotosView: View {
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
-                TitleHeader()
+                TitleHeader(title: "Bridges Photos")
                 HeaderToolBar(bridgeInfoGrouping: $bridgeInfoGrouping)
                 ScrollView {
                     LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {

--- a/PittsburghCityBridges/Views/ContentView.swift
+++ b/PittsburghCityBridges/Views/ContentView.swift
@@ -11,8 +11,7 @@ struct ContentView: View {
     @EnvironmentObject var bridgeStore: BridgeStore
     
     init() {
- //       UITabBar.appearance().isTranslucent = false
- //       UITabBar.appearance().backgroundColor = UIColor.systemBackground
+        UITabBar.appearance().backgroundColor = UIColor.pbTabBarBackground
     }
 
     var body: some View {

--- a/PittsburghCityBridges/Views/TitleHeader.swift
+++ b/PittsburghCityBridges/Views/TitleHeader.swift
@@ -9,10 +9,12 @@ import SwiftUI
 
 struct TitleHeader: View {
     var pbColorPalate = PBColorPalate()
+    var title: String = "Pittsburgh City Bridges"
+
     var body: some View {
         HStack {
             Spacer()
-            Text("Pittsburgh City Bridges")
+            Text(title)
                 .foregroundColor(pbColorPalate.titleTextFgnd)
                 .font(.title2)
                 .italic()


### PR DESCRIPTION
Give tab bar a background.  Adjust light and dark mode colors for tab bar and page headers. update header text copy. 