### PR TITLE
Fix bug where overlays were showing for non-favorite bridges when onl…

### DIFF
--- a/PittsburghCityBridges/Views/Map/BridgeMapUIView.swift
+++ b/PittsburghCityBridges/Views/Map/BridgeMapUIView.swift
@@ -39,6 +39,7 @@ struct BridgeMapUIView: UIViewRepresentable {
     
     func updateUIView(_ mapView: MKMapView, context: Context) {
         logger.info("\(#file) \(#function)")
+        mapView.removeOverlays(mapView.overlays)
         for bridgeModel in bridgeModels {
             let overlays = bridgeModel.polylines
             if overlays.isEmpty { continue }


### PR DESCRIPTION
Fix bug where where when only showing favorite bridges, city maps was showing overlays for bridges that were not favorites. Remove old overlays before adding new ones. 