### PR TITLE
Bar transparency

### DIFF
--- a/PittsburghCityBridges/Appearance/AppColors.swift
+++ b/PittsburghCityBridges/Appearance/AppColors.swift
@@ -14,7 +14,6 @@ extension Color {
 }
 
 extension UIColor {
-    static let pbTabBarBackground = UIColor(Color.pbBgnd)
     static let accentColor = UIColor(named: "AccentColor") ?? UIColor.yellow  // There is also a Color.accentColor define by SwiftUI
 }
 

--- a/PittsburghCityBridges/Assets.xcassets/launchScreenTitleText.colorset/Contents.json
+++ b/PittsburghCityBridges/Assets.xcassets/launchScreenTitleText.colorset/Contents.json
@@ -41,9 +41,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "62",
-          "green" : "184",
-          "red" : "236"
+          "blue" : "147",
+          "green" : "196",
+          "red" : "207"
         }
       },
       "idiom" : "universal"

--- a/PittsburghCityBridges/Views/Bridges/BridgeDetailsView.swift
+++ b/PittsburghCityBridges/Views/Bridges/BridgeDetailsView.swift
@@ -24,6 +24,7 @@ struct BridgeDetailsView: View {
     private var bridgeImageSystem: BridgeImageSystem
     private let imageCornerRadius: CGFloat = 10
     private let imageSmallestMagnification = 1.0
+    private let navBarAppearance = UINavigationBarAppearance()
     private let userInterfaceIdiom: UIUserInterfaceIdiom
     private let logger =  Logger(subsystem: AppLogging.subsystem, category: AppLogging.debugging)
     
@@ -36,6 +37,10 @@ struct BridgeDetailsView: View {
         bridgeImageSystem = BridgeImageSystem()
         self.favorites = favorites
         self.userInterfaceIdiom = UIDevice.current.userInterfaceIdiom
+        navBarAppearance.configureWithDefaultBackground()
+        navBarAppearance.backgroundColor = UIColor(.pbBgnd)
+        UINavigationBar.appearance().standardAppearance = navBarAppearance
+        UINavigationBar.appearance().scrollEdgeAppearance = navBarAppearance
     }
     
     var dragGesture: some Gesture {

--- a/PittsburghCityBridges/Views/Bridges/BridgeDetailsView.swift
+++ b/PittsburghCityBridges/Views/Bridges/BridgeDetailsView.swift
@@ -47,7 +47,7 @@ struct BridgeDetailsView: View {
             }
             .onEnded { value in
                 self.initialDragOffset = CGSize(width: self.initialDragOffset.width + value.translation.width,
-                                             height: self.initialDragOffset.height + value.translation.height)
+                                                height: self.initialDragOffset.height + value.translation.height)
             }
     }
     
@@ -122,16 +122,13 @@ struct BridgeDetailsView: View {
                         VStack(alignment: .leading) {
                             VStack {
                                 HStack {
-                                    Text("\(bridgeModel.name)")
-                                        .font(.headline)
-                                    VStack {
-                                        Spacer()
-                                        Image(systemName: "plus.magnifyingglass")
-                                            .imageScale(.large)
-                                            .foregroundColor(.accentColor)
-                                    }
+                                    Image(systemName: "plus.magnifyingglass")
+                                        .imageScale(.large)
+                                    Text("Zoom")
                                     Spacer()
                                 }
+                                .foregroundColor(.accentColor)
+                                .padding(.top, 10)
                                 HStack {
                                     ZStack {
                                         Image(uiImage: bridgeImage)
@@ -209,6 +206,8 @@ struct BridgeDetailsView: View {
                 })
             }
         }
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle("\(bridgeModel.name)")
         .background(Color.pbBgnd)
         .animation(.default, value: bridgeImageOnly)
     }
@@ -220,7 +219,7 @@ struct BridgeDetailsView: View {
                 HStack {
                     if let _ = bridgeModel.locationCoordinate {
                         Button {
-                                self.showDisclaimerSheet = true
+                            self.showDisclaimerSheet = true
                         } label: {
                             Label("Directions", systemImage: "arrow.triangle.turn.up.right.circle.fill")
                                 .padding(4)
@@ -245,7 +244,7 @@ struct BridgeDetailsView_Previews: PreviewProvider {
     @ObservedObject static var favorites = Favorites()
     static var previews: some View {
         BridgeDetailsView(bridgeModel: BridgeModel.preview, favorites: favorites)
-                 .preferredColorScheme(.dark)
+            .preferredColorScheme(.dark)
         //        BridgeDetailsView(bridgeModel: BridgeModel.preview)
         //            .environmentObject(FavoriteBridges())
         

--- a/PittsburghCityBridges/Views/Bridges/BridgeDetailsView.swift
+++ b/PittsburghCityBridges/Views/Bridges/BridgeDetailsView.swift
@@ -24,7 +24,6 @@ struct BridgeDetailsView: View {
     private var bridgeImageSystem: BridgeImageSystem
     private let imageCornerRadius: CGFloat = 10
     private let imageSmallestMagnification = 1.0
-    private let navBarAppearance = UINavigationBarAppearance()
     private let userInterfaceIdiom: UIUserInterfaceIdiom
     private let logger =  Logger(subsystem: AppLogging.subsystem, category: AppLogging.debugging)
     
@@ -37,10 +36,6 @@ struct BridgeDetailsView: View {
         bridgeImageSystem = BridgeImageSystem()
         self.favorites = favorites
         self.userInterfaceIdiom = UIDevice.current.userInterfaceIdiom
-        navBarAppearance.configureWithDefaultBackground()
-        navBarAppearance.backgroundColor = UIColor(.pbBgnd)
-        UINavigationBar.appearance().standardAppearance = navBarAppearance
-        UINavigationBar.appearance().scrollEdgeAppearance = navBarAppearance
     }
     
     var dragGesture: some Gesture {

--- a/PittsburghCityBridges/Views/Components/FavoritesButton.swift
+++ b/PittsburghCityBridges/Views/Components/FavoritesButton.swift
@@ -36,8 +36,10 @@ struct FavoritesButton: View {
                 } label: {
                     if favorites.contains(element: favorite) {
                         Label("Favorite", systemImage: "star.fill")
+                            .foregroundColor(.accentColor)
                     } else {
                         Label("Favorite", systemImage: "star")
+                            .foregroundColor(.accentColor)
                     }
                 }
             }
@@ -48,14 +50,16 @@ struct FavoritesButton: View {
         var message = ""
         switch favoriteAction {
         case .added:
-            message = "Added to Favorites"
+            message = "Favorite"
         case .removed:
-            message = "Removed from Favorites"
+            message = ""
         case .undefined:
             message = ""
         }
         return VStack {
             Text(message)
+                .font(.body)
+                .foregroundColor(.pbTextFnd)
         }
     }
 }

--- a/PittsburghCityBridges/Views/ContentView.swift
+++ b/PittsburghCityBridges/Views/ContentView.swift
@@ -10,9 +10,13 @@ import SwiftUI
 struct ContentView: View {
     @EnvironmentObject var bridgeStore: BridgeStore
     @StateObject var favorites: Favorites = Favorites()
+    private let tabBarAppearance: UITabBarAppearance = UITabBarAppearance()
     
-    init() {
-        UITabBar.appearance().backgroundColor = UIColor.pbTabBarBackground
+    init() {        
+        tabBarAppearance.configureWithDefaultBackground()
+        tabBarAppearance.backgroundColor = UIColor(Color.pbBgnd)
+        UITabBar.appearance().standardAppearance = tabBarAppearance
+        UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
     }
     
     var body: some View {

--- a/PittsburghCityBridges/Views/ContentView.swift
+++ b/PittsburghCityBridges/Views/ContentView.swift
@@ -10,9 +10,15 @@ import SwiftUI
 struct ContentView: View {
     @EnvironmentObject var bridgeStore: BridgeStore
     @StateObject var favorites: Favorites = Favorites()
+    private let navBarAppearance = UINavigationBarAppearance()
     private let tabBarAppearance: UITabBarAppearance = UITabBarAppearance()
     
-    init() {        
+    init() {
+        navBarAppearance.configureWithDefaultBackground()
+        navBarAppearance.backgroundColor = UIColor(.pbBgnd)
+        UINavigationBar.appearance().standardAppearance = navBarAppearance
+        UINavigationBar.appearance().scrollEdgeAppearance = navBarAppearance
+
         tabBarAppearance.configureWithDefaultBackground()
         tabBarAppearance.backgroundColor = UIColor(Color.pbBgnd)
         UITabBar.appearance().standardAppearance = tabBarAppearance

--- a/PittsburghCityBridges/Views/ContentView.swift
+++ b/PittsburghCityBridges/Views/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
     init() {
         navBarAppearance.configureWithDefaultBackground()
         navBarAppearance.backgroundColor = UIColor(.pbBgnd)
+        navBarAppearance.titleTextAttributes = [.foregroundColor: UIColor(.pbTextFnd)]
         UINavigationBar.appearance().standardAppearance = navBarAppearance
         UINavigationBar.appearance().scrollEdgeAppearance = navBarAppearance
 

--- a/PittsburghCityBridges/Views/More/AppIconCreditsScreen.swift
+++ b/PittsburghCityBridges/Views/More/AppIconCreditsScreen.swift
@@ -44,7 +44,7 @@ struct AppIconCreditsScreen: View {
                     .cornerRadius(10)
                     .padding(.vertical)
                     .padding([.leading], 20.0)
-                Text("Pittsburgh City Bridges App Icon created Aidan K. Who is demonstrating some natural talent and real skill at 10 years old")
+                Text("Pittsburgh City Bridges App Icon created by Aidan K. Who is showing nice talent and new skills at 10 years old")
                     .padding(.trailing)
                     .foregroundColor(.pbTextFnd)
             }

--- a/PittsburghCityBridges/Views/More/AppIconCreditsScreen.swift
+++ b/PittsburghCityBridges/Views/More/AppIconCreditsScreen.swift
@@ -15,10 +15,10 @@ struct AppIconCreditsScreen: View {
     var body: some View {
         ScrollView {
             VStack {
-                Text("App Icon")
-                    .font(.title2)
-                    .italic()
-                    .foregroundColor(.pbTextFnd)
+//                Text("App Icon")
+//                    .font(.title2)
+//                    .italic()
+//                    .foregroundColor(.pbTextFnd)
                 VStack {
                     aidensCredit()
                         .frame(minHeight: 100)
@@ -28,6 +28,8 @@ struct AppIconCreditsScreen: View {
                 .padding()
             }
         }
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle("App Icon")
         .background(Color.pbBgnd)
     }
     
@@ -45,8 +47,9 @@ struct AppIconCreditsScreen: View {
                     .cornerRadius(10)
                     .padding(.vertical)
                     .padding([.leading], 20.0)
-                Text("Pittsburgh City Bridges App Icon created by 10 year old Aidan K.")
+                Text("Pittsburgh City Bridges App Icon created Aidan K. Who is demonstrating some natural talent and real skill at 10 years old")
                     .padding(.trailing)
+                    .foregroundColor(.pbTextFnd)
             }
         }
     }

--- a/PittsburghCityBridges/Views/More/AppIconCreditsScreen.swift
+++ b/PittsburghCityBridges/Views/More/AppIconCreditsScreen.swift
@@ -15,14 +15,11 @@ struct AppIconCreditsScreen: View {
     var body: some View {
         ScrollView {
             VStack {
-//                Text("App Icon")
-//                    .font(.title2)
-//                    .italic()
-//                    .foregroundColor(.pbTextFnd)
+
                 VStack {
                     aidensCredit()
-                        .frame(minHeight: 100)
-                        .padding(.bottom)
+                        .frame(minHeight: 150)
+                        .padding()
                     Spacer()
                 }
                 .padding()

--- a/PittsburghCityBridges/Views/More/OpenDataCreditsScreen.swift
+++ b/PittsburghCityBridges/Views/More/OpenDataCreditsScreen.swift
@@ -15,10 +15,6 @@ struct OpenDataCreditsScreen: View {
     var body: some View {
         ScrollView {
             VStack {
-                Text("Open Data Source")
-                    .font(.title2)
-                    .italic()
-                    .foregroundColor(.pbTextFnd)
                 VStack {
                     openDataCredit()
                         .frame(minHeight: 200)
@@ -27,6 +23,8 @@ struct OpenDataCreditsScreen: View {
                 .padding()
             }
         }
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle("Open Data Source")
         .background(Color.pbBgnd)
     }
     
@@ -40,6 +38,7 @@ struct OpenDataCreditsScreen: View {
                 VStack(alignment: .leading){
                     Text("This App uses the City of Pittsburgh Bridges Open Data dataset provided by  the [Western Pennsylvania Regional Data Center](http://www.wprdc.org). This bridge data includes names, locations, gps coordinates and photos. This dataset is one of over 300 publicly available Open Data datasets provided by the WPRDC")
                         .font(.body)
+                        .foregroundColor(.pbTextFnd)
                         .multilineTextAlignment(.leading)
                     
                 }


### PR DESCRIPTION
Nav bar and Tab bar are not opaque and stay that way when scrolling.  Before they would be translucent which did not look right, especially in light mode.  

BridgeDetailView put bridge title inline in nav bar and remove from being above detailed photo.  looks better

a few places especially in more screens where text was white instead of gold