### PR TITLE
Startup refactor

### DIFF
--- a/PittsburghCityBridges/Constants/StorageKeys.swift
+++ b/PittsburghCityBridges/Constants/StorageKeys.swift
@@ -8,5 +8,4 @@
 import Foundation
 
 struct StorageKeys {
-    static let onBoardingComplete = "com.mak.pcb.onboard.complete"
 }

--- a/PittsburghCityBridges/Constants/TextCopy.swift
+++ b/PittsburghCityBridges/Constants/TextCopy.swift
@@ -20,13 +20,13 @@ App maker assumes no legal liability or responsibility for any loss, damage, inj
 No representation is made or warranty given as to data content, route practicability, efficiency, or map accuracy.
 """
     static let onBoardingIntroFirstPart = """
-This Pittsburgh City Bridges app contains information on over 140 bridges publicly available from the City of Pittsburgh Bridges OpenData database.
+This Pittsburgh City Bridges app contains information on over 140 bridges publicly available from the City of Pittsburgh Bridges Open Data database.
 
-These city bridges cross roads, ravines, and streams. They are old bridges, new bridges, small, medium and large bridges.
+This app does not have the big bridges that cross any of the three rivers because they are not in the City of Pittsburgh Bridges Open Data database.
 
-None span the rivers save two, the Fort Duquesne Pedestrian Bridge and the Hot Metal Pedestrian Bridge. Both can be found in this app.
+Instead the bridges in this app cross roads, ravines, and streams and are understood to be city maintained bridges.
 
-Bridge information provided includes bridge name, neighborhood, year built, gps location, and photos.
+Search bridges by neighborhood, name and year built.
 
 """
     

--- a/PittsburghCityBridges/PittsburghCityBridgesApp.swift
+++ b/PittsburghCityBridges/PittsburghCityBridgesApp.swift
@@ -10,23 +10,12 @@ import SwiftUI
 @main
 struct PittsburghCityBridgesApp: App {
     //    let persistenceController = PersistenceController.shared
-    @AppStorage(StorageKeys.onBoardingComplete) private var onBoardingComplete = false
     @StateObject var bridgeStore: BridgeStore = BridgeStore()
     
-    init() {
-        #if DEBUG
-        // onBoardingComplete = false
-        #endif
-        // beta test flag
-    }
     var body: some Scene {
         WindowGroup {
-            if onBoardingComplete {
                 ContentView()
                     .environmentObject(bridgeStore)
-            } else {
-                OnBoardingContentView()
-            }
             // CloudKitContentView()
             //        .environment(\.managedObjectContext, persistenceController.container.viewContext)
         }

--- a/PittsburghCityBridges/Views/ContentView.swift
+++ b/PittsburghCityBridges/Views/ContentView.swift
@@ -28,17 +28,17 @@ struct ContentView: View {
     
     var body: some View {
         TabView {
-            BridgeMapView()
+            BridgesListsView(BridgeListViewModel(bridgeStore))
                 .tabItem {
-                    Label("Map", systemImage: "map")
+                    Label("List", systemImage: "list.dash")
                 }
             BridgesPhotosListView(BridgeListViewModel(bridgeStore))
                 .tabItem {
                     Label("Photos", systemImage: "photo.on.rectangle")
                 }
-            BridgesListsView(BridgeListViewModel(bridgeStore))
+            BridgeMapView()
                 .tabItem {
-                    Label("List", systemImage: "list.dash")
+                    Label("Map", systemImage: "map")
                 }
             MoreScreenView()
                 .tabItem {

--- a/PittsburghCityBridges/Views/More/MoreScreenView.swift
+++ b/PittsburghCityBridges/Views/More/MoreScreenView.swift
@@ -18,31 +18,29 @@ struct MoreScreenView: View {
                 TitleHeader(title: "Pittsburgh City Bridges")
                 NavigationView {
                     List {
-                     
-                        NavigationLink {
-                            OpenDataCreditsScreen()
-                        }
-                    label: {
-                        Label("Open Data Source - WPRDC", systemImage: "slider.vertical.3")
-                    }
-                    .listRowBackground(Color.pbBgnd)
-                        NavigationLink {
+                    NavigationLink {
                             OnBoardingContentView()
                         }
                     label: {
-                        Label("App Intro Screens", systemImage: "sum")
+                        Label("App Overview", systemImage: "questionmark")
                     }
                     .listRowBackground(Color.pbBgnd)
-                        NavigationLink {
+                    NavigationLink {
                             AppIconCreditsScreen()
                         }
                     label: {
-                        Label("App Icon Designer", systemImage: "megaphone")
+                        Label("App Icon Designer", systemImage: "person.crop.square")
                     }
                     .listRowBackground(Color.pbBgnd)
+                        NavigationLink {
+                                OpenDataCreditsScreen()
+                            }
+                        label: {
+                            Label("Open Data Source - WPRDC", systemImage: "folder")
+                        }
+                        .listRowBackground(Color.pbBgnd)
                     }
                     .foregroundColor(Color.pbTextFnd)
-                    
                 }
                 .navigationViewStyle(StackNavigationViewStyle())
             }

--- a/PittsburghCityBridges/Views/Onboarding/OnBoardingCloseScreen.swift
+++ b/PittsburghCityBridges/Views/Onboarding/OnBoardingCloseScreen.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct OnBoardingCloseScreen: View {
-    @Binding var onBoardingComplete: Bool
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -16,22 +15,6 @@ struct OnBoardingCloseScreen: View {
             Text(AppTextCopy.onBoardingCloseScreen)
                 .font(UIDevice.current.userInterfaceIdiom == .phone ? .subheadline : .title2)
             .padding()
-            if !onBoardingComplete {
-                HStack {
-                    Spacer()
-                    Button(AppTextCopy.onBoardingCloseScreenButton) {
-                        onBoardingComplete  = true
-                    }
-                    .padding(.vertical, 15)
-                    .padding(.horizontal, 40)
-                    .background(
-                        RoundedRectangle(cornerRadius: PCBButton.cornerRadius)
-                            .stroke(Color.accentColor, lineWidth: 2)
-                    )
-                    Spacer()
-                }
-                .padding(.vertical, 20)
-            }
             Spacer()
         }
         .frame(maxWidth: UIDevice.current.userInterfaceIdiom == .phone ? 350 : 700)
@@ -43,8 +26,8 @@ struct OnBoardingCloseScreen: View {
 
 struct OnBoardingCloseScreen_Previews: PreviewProvider {
     static var previews: some View {
-        OnBoardingCloseScreen(onBoardingComplete: .constant(false))
-        OnBoardingCloseScreen(onBoardingComplete: .constant(false))
+        OnBoardingCloseScreen()
+        OnBoardingCloseScreen()
             .preferredColorScheme(.dark)
     }
 }

--- a/PittsburghCityBridges/Views/Onboarding/OnBoardingContentView.swift
+++ b/PittsburghCityBridges/Views/Onboarding/OnBoardingContentView.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 
 struct OnBoardingContentView: View {
-    @AppStorage(StorageKeys.onBoardingComplete) private var onBoardingComplete = false
-    @State var done = false
  
     var body: some View {
         TabView {
@@ -19,15 +17,9 @@ struct OnBoardingContentView: View {
             OnBoardingBrowseScreen()
             OnBoardingSortAndSearchScreen()
             OnboardingCollapsedBridgeScreen()
-            OnBoardingCloseScreen(onBoardingComplete: $done)
+            OnBoardingCloseScreen()
         }
         .background(Color.pbBgnd)
-        .onChange(of: done, perform: { newValue in
-            onBoardingComplete = done
-        })
-        .onAppear(perform: {
-            done = onBoardingComplete
-        })
         .tabViewStyle(.page(indexDisplayMode: .always))
     }
 }

--- a/PittsburghCityBridges/Views/Onboarding/OnBoardingContentView.swift
+++ b/PittsburghCityBridges/Views/Onboarding/OnBoardingContentView.swift
@@ -12,12 +12,12 @@ struct OnBoardingContentView: View {
     var body: some View {
         TabView {
             OnBoardingIntroScreen()
-            OnBoardingBridgePhotosScreen()
-            OnBoardingMapScreen()
-            OnBoardingBrowseScreen()
-            OnBoardingSortAndSearchScreen()
-            OnboardingCollapsedBridgeScreen()
-            OnBoardingCloseScreen()
+//            OnBoardingBridgePhotosScreen()
+//            OnBoardingBrowseScreen()
+//            OnBoardingMapScreen()
+//            OnBoardingSortAndSearchScreen()
+//            OnboardingCollapsedBridgeScreen()
+//            OnBoardingCloseScreen()
         }
         .background(Color.pbBgnd)
         .tabViewStyle(.page(indexDisplayMode: .always))

--- a/PittsburghCityBridges/Views/Onboarding/OnBoardingSortAndSearchScreen.swift
+++ b/PittsburghCityBridges/Views/Onboarding/OnBoardingSortAndSearchScreen.swift
@@ -30,11 +30,6 @@ struct OnBoardingSortAndSearchScreen: View {
                 .aspectRatio(1.0, contentMode: .fill)
                 .frame(width: imageSize.width, height: imageSize.height)
                 .padding(.bottom, 20)
-            Text("Bridge Photos Sort and Search")
-            Image("sortPhotos")
-                .resizable()
-                .aspectRatio(1.0, contentMode: .fill)
-                .frame(width: imageSize.width, height: imageSize.height)
             Spacer()
         }
         .background(Color.pbBgnd)


### PR DESCRIPTION
Stopped displaying OnBoarding Screens when app installed and run. Instead moved screens to under the more tab, removed all onboard screens from display except but one. 