### PR TITLE
Assign MapView to main ContentView TabBar's First Tab

### DIFF
--- a/PittsburghCityBridges/Views/ContentView.swift
+++ b/PittsburghCityBridges/Views/ContentView.swift
@@ -28,6 +28,10 @@ struct ContentView: View {
     
     var body: some View {
         TabView {
+            BridgeMapView()
+                .tabItem {
+                    Label("Map", systemImage: "map")
+                }
             BridgesListsView(BridgeSearcher(bridgeStore))
                 .tabItem {
                     Label("List", systemImage: "list.dash")
@@ -35,10 +39,6 @@ struct ContentView: View {
             BridgesPhotosListView(BridgeSearcher(bridgeStore))
                 .tabItem {
                     Label("Photos", systemImage: "photo.on.rectangle")
-                }
-            BridgeMapView()
-                .tabItem {
-                    Label("Map", systemImage: "map")
                 }
             MoreScreenView()
                 .tabItem {


### PR DESCRIPTION
The default view when user launches the app is now the Bridges Map View.  Showing the individual bridges. Showing this view is nicer than display a text list for the bridges. 